### PR TITLE
feat: website auditor + 1-5 scoring + Sheet qualification filter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - run: pytest

--- a/src/shmoney/audit.py
+++ b/src/shmoney/audit.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+import re
+import time
+from typing import Optional
+
+import httpx
+
+
+@dataclass(frozen=True)
+class AuditFlags:
+    reachable: bool
+    https: bool
+    redirects_to_https: bool
+    has_viewport: bool
+    body_substantial: bool
+    response_time_ok: bool
+    last_modified_fresh: bool
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    flags: AuditFlags
+    fetched_at: str
+    status_code: int
+    elapsed_ms: int
+
+
+_VIEWPORT_RE = re.compile(r"<meta[^>]+name=['\"]viewport['\"]", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+_BODY_MIN_CHARS = 200
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_scheme(url: str) -> str:
+    return url if "://" in url else "https://" + url
+
+
+def _strip_text(html: str) -> str:
+    return _TAG_RE.sub(" ", html)
+
+
+def _last_modified_fresh(header: Optional[str], stale_days: int) -> bool:
+    # Absent header: don't penalize; many healthy sites omit it.
+    if not header:
+        return True
+    try:
+        dt = parsedate_to_datetime(header)
+    except (TypeError, ValueError):
+        return True
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - dt <= timedelta(days=stale_days)
+
+
+class WebsiteAuditor:
+    def __init__(
+        self,
+        client: Optional[httpx.Client] = None,
+        timeout: float = 10.0,
+        response_ms_threshold: int = 3000,
+        stale_days: int = 365,
+    ):
+        self._client = client or httpx.Client(follow_redirects=True, timeout=timeout)
+        self._owns_client = client is None
+        self._response_ms_threshold = response_ms_threshold
+        self._stale_days = stale_days
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def audit(self, url: str) -> AuditReport:
+        original = _ensure_scheme(url)
+        original_scheme = original.split("://", 1)[0].lower()
+        t0 = time.perf_counter()
+        try:
+            resp = self._client.get(original)
+        except httpx.HTTPError:
+            return AuditReport(
+                flags=AuditFlags(
+                    reachable=False,
+                    https=False,
+                    redirects_to_https=False,
+                    has_viewport=False,
+                    body_substantial=False,
+                    response_time_ok=False,
+                    last_modified_fresh=False,
+                ),
+                fetched_at=_now_iso(),
+                status_code=0,
+                elapsed_ms=0,
+            )
+
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        reachable = 200 <= resp.status_code < 300
+        final_scheme = resp.url.scheme.lower()
+        is_https = final_scheme == "https"
+        redirects_to_https = original_scheme == "http" and is_https
+
+        body = resp.text if reachable else ""
+        has_viewport = bool(_VIEWPORT_RE.search(body))
+        body_substantial = len(_strip_text(body).strip()) >= _BODY_MIN_CHARS
+
+        flags = AuditFlags(
+            reachable=reachable,
+            https=is_https if reachable else False,
+            redirects_to_https=redirects_to_https if reachable else False,
+            has_viewport=has_viewport,
+            body_substantial=body_substantial,
+            response_time_ok=reachable and elapsed_ms < self._response_ms_threshold,
+            last_modified_fresh=reachable
+            and _last_modified_fresh(resp.headers.get("last-modified"), self._stale_days),
+        )
+        return AuditReport(
+            flags=flags,
+            fetched_at=_now_iso(),
+            status_code=resp.status_code,
+            elapsed_ms=elapsed_ms,
+        )

--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -1,5 +1,6 @@
 import typer
 
+from .audit import WebsiteAuditor
 from .config import load_config
 from .orchestrator import run_once
 from .repo import Repository
@@ -78,7 +79,11 @@ def run(
             raise typer.BadParameter(f"source {source!r} not implemented")
         ws = _GspreadWorksheetAdapter(_gspread_worksheet(cfg))
         writer = SheetsWriter(ws)
-        n = run_once(adapter, repo, writer)
+        auditor = WebsiteAuditor()
+        try:
+            n = run_once(adapter, repo, writer, auditor)
+        finally:
+            auditor.close()
         typer.echo(f"upserted {n} rows")
     finally:
         repo.close()

--- a/src/shmoney/orchestrator.py
+++ b/src/shmoney/orchestrator.py
@@ -2,9 +2,11 @@ from dataclasses import asdict
 from datetime import date
 from typing import Optional
 
+from .audit import WebsiteAuditor
 from .canonicalize import canonical_key
 from .classify import classify, consulting_opportunity_tag
 from .repo import Repository
+from .scorer import score
 from .sheets import SheetsWriter
 from .sources.base import SourceAdapter
 
@@ -35,7 +37,12 @@ def _years_in_business(registered_at: Optional[str]) -> Optional[str]:
     return str(diff) if diff >= 0 else None
 
 
-def run_once(adapter: SourceAdapter, repo: Repository, sheets: SheetsWriter) -> int:
+def run_once(
+    adapter: SourceAdapter,
+    repo: Repository,
+    sheets: SheetsWriter,
+    auditor: Optional[WebsiteAuditor] = None,
+) -> int:
     sheets.ensure_schema()
     written = 0
     for raw in adapter.iter_businesses():
@@ -46,7 +53,19 @@ def run_once(adapter: SourceAdapter, repo: Repository, sheets: SheetsWriter) -> 
         merged = repo.get_business(key) or {}
 
         classification = classify(merged.get("website"))
-        if classification.kind == "real":
+
+        audit_report = None
+        if classification.kind == "real" and merged.get("website") and auditor is not None:
+            if repo.is_audit_fresh(key, max_age_days=30):
+                audit_report = repo.get_audit(key)
+            else:
+                audit_report = auditor.audit(merged["website"])
+                repo.record_audit(key, audit_report)
+
+        s, tag = score(classification, audit_report)
+
+        # Qualification filter: drop strong real sites from the Sheet.
+        if classification.kind == "real" and s >= 4:
             continue
 
         business_row: dict[str, str] = {}
@@ -58,7 +77,11 @@ def run_once(adapter: SourceAdapter, repo: Repository, sheets: SheetsWriter) -> 
         yib = _years_in_business(merged.get("registered_at"))
         if yib is not None:
             business_row["Years in Business"] = yib
-        business_row["Consulting Opportunity"] = consulting_opportunity_tag(classification)
+        co_tag = consulting_opportunity_tag(classification)
+        if not co_tag and tag:
+            co_tag = tag
+        business_row["Consulting Opportunity"] = co_tag
+        business_row["Online Presence\n(1-5 scale)"] = str(s)
 
         row_idx = sheets.upsert(key, business_row)
         repo.record_sheet_row(key, row_idx)

--- a/src/shmoney/repo.py
+++ b/src/shmoney/repo.py
@@ -1,8 +1,10 @@
 import json
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
+from .audit import AuditFlags, AuditReport
 from .sources.base import RawBusiness
 
 _SCHEMA = """
@@ -35,6 +37,20 @@ CREATE TABLE IF NOT EXISTS sheet_row_map (
     canonical_key TEXT PRIMARY KEY,
     row_index INTEGER NOT NULL,
     last_written_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS audits (
+    canonical_key TEXT PRIMARY KEY,
+    reachable INTEGER NOT NULL,
+    https INTEGER NOT NULL,
+    redirects_to_https INTEGER NOT NULL,
+    has_viewport INTEGER NOT NULL,
+    body_substantial INTEGER NOT NULL,
+    response_time_ok INTEGER NOT NULL,
+    last_modified_fresh INTEGER NOT NULL,
+    fetched_at TEXT NOT NULL,
+    status_code INTEGER,
+    elapsed_ms INTEGER
 );
 """
 
@@ -114,6 +130,77 @@ class Repository:
             (canonical_key,),
         ).fetchone()
         return int(row["row_index"]) if row else None
+
+    def record_audit(self, canonical_key: str, report: AuditReport) -> None:
+        f = report.flags
+        self.conn.execute(
+            """
+            INSERT INTO audits (
+                canonical_key, reachable, https, redirects_to_https,
+                has_viewport, body_substantial, response_time_ok,
+                last_modified_fresh, fetched_at, status_code, elapsed_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(canonical_key) DO UPDATE SET
+                reachable = excluded.reachable,
+                https = excluded.https,
+                redirects_to_https = excluded.redirects_to_https,
+                has_viewport = excluded.has_viewport,
+                body_substantial = excluded.body_substantial,
+                response_time_ok = excluded.response_time_ok,
+                last_modified_fresh = excluded.last_modified_fresh,
+                fetched_at = excluded.fetched_at,
+                status_code = excluded.status_code,
+                elapsed_ms = excluded.elapsed_ms
+            """,
+            (
+                canonical_key,
+                int(f.reachable),
+                int(f.https),
+                int(f.redirects_to_https),
+                int(f.has_viewport),
+                int(f.body_substantial),
+                int(f.response_time_ok),
+                int(f.last_modified_fresh),
+                report.fetched_at,
+                report.status_code,
+                report.elapsed_ms,
+            ),
+        )
+
+    def get_audit(self, canonical_key: str) -> Optional[AuditReport]:
+        row = self.conn.execute(
+            "SELECT * FROM audits WHERE canonical_key = ?", (canonical_key,)
+        ).fetchone()
+        if not row:
+            return None
+        return AuditReport(
+            flags=AuditFlags(
+                reachable=bool(row["reachable"]),
+                https=bool(row["https"]),
+                redirects_to_https=bool(row["redirects_to_https"]),
+                has_viewport=bool(row["has_viewport"]),
+                body_substantial=bool(row["body_substantial"]),
+                response_time_ok=bool(row["response_time_ok"]),
+                last_modified_fresh=bool(row["last_modified_fresh"]),
+            ),
+            fetched_at=row["fetched_at"],
+            status_code=int(row["status_code"]) if row["status_code"] is not None else 0,
+            elapsed_ms=int(row["elapsed_ms"]) if row["elapsed_ms"] is not None else 0,
+        )
+
+    def is_audit_fresh(self, canonical_key: str, max_age_days: int = 30) -> bool:
+        row = self.conn.execute(
+            "SELECT fetched_at FROM audits WHERE canonical_key = ?", (canonical_key,)
+        ).fetchone()
+        if not row:
+            return False
+        try:
+            dt = datetime.fromisoformat(row["fetched_at"])
+        except ValueError:
+            return False
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) - dt <= timedelta(days=max_age_days)
 
     def close(self) -> None:
         self.conn.close()

--- a/src/shmoney/scorer.py
+++ b/src/shmoney/scorer.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from .audit import AuditReport
+from .classify import Classification
+
+
+def score(c: Classification, report: Optional[AuditReport]) -> tuple[int, str]:
+    if c.kind == "none":
+        return 1, "no website"
+    if c.kind == "social":
+        return 2, f"social-only ({c.platform})"
+    # kind == "real"
+    if report is None:
+        return 3, ""
+    f = report.flags
+    if not f.reachable:
+        return 1, "site broken"
+    s = 3
+    if f.https or f.redirects_to_https:
+        s += 1
+    if f.has_viewport and f.body_substantial:
+        s += 1
+    if not f.response_time_ok:
+        s -= 1
+    if not f.last_modified_fresh:
+        s -= 1
+    s = max(1, min(5, s))
+    tag = "" if s >= 4 else "weak site"
+    return s, tag

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -1,0 +1,105 @@
+from email.utils import format_datetime
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from shmoney.audit import WebsiteAuditor
+
+
+_GOOD_HTML = (
+    "<html><head><meta name='viewport' content='width=device-width'></head>"
+    "<body>" + ("Welcome to our bakery. " * 40) + "</body></html>"
+)
+_PLACEHOLDER_HTML = "<html><body>Coming soon.</body></html>"
+
+
+def _auditor(handler):
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, follow_redirects=True, timeout=5.0)
+    return WebsiteAuditor(client=client)
+
+
+def test_reachable_https_viewport_fresh_all_true():
+    fresh = format_datetime(datetime.now(timezone.utc))
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, html=_GOOD_HTML, headers={"last-modified": fresh}
+        )
+
+    a = _auditor(handler)
+    r = a.audit("https://example.com")
+    f = r.flags
+    assert f.reachable and f.https and f.has_viewport
+    assert f.body_substantial and f.response_time_ok and f.last_modified_fresh
+    assert r.status_code == 200
+
+
+def test_http_only_no_redirect():
+    def handler(req):
+        return httpx.Response(200, html=_GOOD_HTML)
+
+    r = _auditor(handler).audit("http://example.com")
+    assert r.flags.reachable
+    assert not r.flags.https
+    assert not r.flags.redirects_to_https
+
+
+def test_http_redirects_to_https():
+    def handler(req):
+        if req.url.scheme == "http":
+            return httpx.Response(
+                301, headers={"location": "https://example.com/"}
+            )
+        return httpx.Response(200, html=_GOOD_HTML)
+
+    r = _auditor(handler).audit("http://example.com")
+    assert r.flags.https
+    assert r.flags.redirects_to_https
+
+
+def test_404_unreachable():
+    def handler(req):
+        return httpx.Response(404, html="not found")
+
+    r = _auditor(handler).audit("https://example.com")
+    assert not r.flags.reachable
+    assert r.status_code == 404
+
+
+def test_timeout_unreachable():
+    def handler(req):
+        raise httpx.ConnectTimeout("boom", request=req)
+
+    r = _auditor(handler).audit("https://example.com")
+    assert not r.flags.reachable
+    assert r.status_code == 0
+
+
+def test_placeholder_page():
+    def handler(req):
+        return httpx.Response(200, html=_PLACEHOLDER_HTML)
+
+    r = _auditor(handler).audit("https://example.com")
+    assert r.flags.reachable
+    assert not r.flags.has_viewport
+    assert not r.flags.body_substantial
+
+
+def test_stale_last_modified():
+    old = format_datetime(datetime.now(timezone.utc) - timedelta(days=800))
+
+    def handler(req):
+        return httpx.Response(200, html=_GOOD_HTML, headers={"last-modified": old})
+
+    r = _auditor(handler).audit("https://example.com")
+    assert not r.flags.last_modified_fresh
+
+
+def test_missing_last_modified_treated_fresh():
+    def handler(req):
+        return httpx.Response(200, html=_GOOD_HTML)
+
+    r = _auditor(handler).audit("https://example.com")
+    assert r.flags.last_modified_fresh

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,114 @@
+import pytest
+
+from shmoney.audit import AuditFlags, AuditReport
+from shmoney.classify import Classification
+from shmoney.scorer import score
+
+
+def _flags(**overrides):
+    base = dict(
+        reachable=True,
+        https=True,
+        redirects_to_https=False,
+        has_viewport=True,
+        response_time_ok=True,
+        last_modified_fresh=True,
+        body_substantial=True,
+    )
+    base.update(overrides)
+    return AuditFlags(**base)
+
+
+def _report(**overrides):
+    return AuditReport(
+        flags=_flags(**overrides),
+        fetched_at="2026-04-18T00:00:00",
+        status_code=200,
+        elapsed_ms=100,
+    )
+
+
+def test_no_website():
+    c = Classification(kind="none", platform=None, url="")
+    s, tag = score(c, None)
+    assert s == 1
+    assert tag == "no website"
+
+
+def test_social_only():
+    c = Classification(kind="social", platform="facebook", url="https://facebook.com/x")
+    s, tag = score(c, None)
+    assert s == 2
+    assert tag == "social-only (facebook)"
+
+
+def test_real_site_pending_audit():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, tag = score(c, None)
+    assert s == 3
+    assert tag == ""
+
+
+def test_real_site_all_good():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, tag = score(c, _report())
+    assert s == 5
+    assert tag == ""
+
+
+def test_real_site_unreachable():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, tag = score(c, _report(reachable=False, https=False, has_viewport=False,
+                              response_time_ok=False, last_modified_fresh=False,
+                              body_substantial=False))
+    assert s == 1
+    assert tag == "site broken"
+
+
+def test_real_site_http_only_drops_score():
+    c = Classification(kind="real", platform=None, url="http://x.com")
+    s_secure, _ = score(c, _report())
+    s_http, _ = score(c, _report(https=False, redirects_to_https=False))
+    assert s_http < s_secure
+
+
+def test_real_site_redirect_to_https_counts_as_secure():
+    c = Classification(kind="real", platform=None, url="http://x.com")
+    s, _ = score(c, _report(https=False, redirects_to_https=True))
+    assert s == 5
+
+
+def test_real_site_slow_loses_point():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, _ = score(c, _report(response_time_ok=False))
+    assert s == 4
+
+
+def test_real_site_stale_loses_point():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, _ = score(c, _report(last_modified_fresh=False))
+    assert s == 4
+
+
+def test_real_site_placeholder_low_score():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, tag = score(c, _report(has_viewport=False, body_substantial=False,
+                              last_modified_fresh=False, response_time_ok=False))
+    assert s <= 2
+    assert tag == "weak site"
+
+
+def test_real_site_score_clamped_1_to_5():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    # worst case (but reachable): should not go below 1
+    s, _ = score(c, _report(https=False, redirects_to_https=False, has_viewport=False,
+                            body_substantial=False, response_time_ok=False,
+                            last_modified_fresh=False))
+    assert 1 <= s <= 5
+
+
+def test_real_site_weak_site_tag_when_below_4():
+    c = Classification(kind="real", platform=None, url="https://x.com")
+    s, tag = score(c, _report(response_time_ok=False, last_modified_fresh=False))
+    assert s == 3
+    assert tag == "weak site"

--- a/tests/test_smoke_pipeline.py
+++ b/tests/test_smoke_pipeline.py
@@ -1,8 +1,26 @@
+from shmoney.audit import AuditFlags, AuditReport
 from shmoney.canonicalize import canonical_key
 from shmoney.orchestrator import run_once
 from shmoney.repo import Repository
 from shmoney.sheets import COLUMNS, SheetsWriter
 from shmoney.sources.base import RawBusiness, SourceAdapter
+
+
+class _StrongAuditor:
+    def audit(self, url):
+        return AuditReport(
+            flags=AuditFlags(
+                reachable=True, https=True, redirects_to_https=False,
+                has_viewport=True, body_substantial=True,
+                response_time_ok=True, last_modified_fresh=True,
+            ),
+            fetched_at="2026-04-19T00:00:00+00:00",
+            status_code=200,
+            elapsed_ms=100,
+        )
+
+    def close(self):
+        pass
 
 
 class StubAdapter(SourceAdapter):
@@ -83,7 +101,7 @@ def test_real_website_filtered_out(tmp_path, fake_ws):
     )
     repo = Repository(tmp_path / "t.db")
     writer = SheetsWriter(fake_ws)
-    n = run_once(StubAdapter([has_real, no_site, social]), repo, writer)
+    n = run_once(StubAdapter([has_real, no_site, social]), repo, writer, _StrongAuditor())
     assert n == 2  # real-site business excluded
     tags = [fake_ws.rows[r][_col("Consulting Opportunity")] for r in (1, 2)]
     assert "no website" in tags


### PR DESCRIPTION
Closes #5.

## Summary
- `WebsiteAuditor` (httpx) — extracts reachable/https/redirect/viewport/body/response-time/last-modified flags
- `Scorer` — Classification + AuditReport → 1-5 score + Consulting Opportunity tag
- `audits` table on Repository with `record_audit`/`get_audit`/`is_audit_fresh` (30-day TTL)
- Orchestrator audits `kind=="real"` sites, writes "Online Presence (1-5)" column, and filters score ≥ 4 out of the Sheet
- Fixture-based tests for auditor; table-driven tests for scorer

## Test plan
- [x] `pytest` green (69 tests, CI will run)
- [x] `pipeline run --source yelp --limit 5` — confirm rows in `audits` table
- [x] Confirm Sheet rows include "Online Presence (1-5)" populated
- [x] Confirm a known strong-site business is excluded from Sheet
- [x] Re-run within 30 days — no re-audit (check `fetched_at` unchanged)

Out of scope: `--reaudit` flag (deferred to #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)