### PR TITLE
feat: add Facebook Pages adapter (public HTML scrape)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # shmoney-scraper
+
+## Source adapters
+
+### Facebook Pages (v1 status: blocked by robots.txt)
+
+`FacebookPagesAdapter` scrapes public Page HTML with a pre-fetch
+`urllib.robotparser` check. In practice, `facebook.com/robots.txt` disallows
+every user-agent not on Meta's allowlist, so a compliant run against real
+Pages emits 0 rows:
+
+```
+$ pipeline run --source facebook --limit 2
+upserted 0 rows
+```
+
+This is the correct behavior per the PRD ("respect robots.txt, no anti-bot
+evasion"). The adapter, tests, rate limiter, and loud-fail parser are in
+place and exercised by fixtures, so the module is ready to plug into a
+lawful access path when one is chosen.
+
+Practical paths forward (deferred beyond v1):
+
+- **Graph API** via an approved app + Page access token — the intended
+  long-term route; would replace the HTML scrape entirely.
+- **Operator-supplied Page data** (export / manual copy) fed through the
+  same adapter surface.
+
+Do not bypass the robots check. If a future run ever needs to hit Facebook
+HTML, the UA must be on Meta's allowlist or the access path must switch to
+the Graph API.

--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -5,6 +5,7 @@ from .config import load_config
 from .orchestrator import run_once
 from .repo import Repository
 from .sheets import SheetsWriter
+from .sources.facebook import FacebookPagesAdapter
 from .sources.opencorporates import OpenCorporatesMDAdapter
 from .sources.yelp import YelpFusionAdapter
 
@@ -73,6 +74,22 @@ def run(
             adapter = OpenCorporatesMDAdapter(
                 api_token=cfg.opencorporates_api_token,
                 query=cfg.opencorporates_query or term,
+                limit=limit,
+            )
+        elif source == "facebook":
+            seeds_path = cfg.facebook_seeds_file
+            if not seeds_path.exists():
+                raise typer.BadParameter(
+                    f"facebook seeds file not found: {seeds_path}"
+                )
+            urls = [
+                line.strip()
+                for line in seeds_path.read_text().splitlines()
+                if line.strip() and not line.startswith("#")
+            ]
+            adapter = FacebookPagesAdapter(
+                user_agent=cfg.facebook_user_agent,
+                page_urls=urls,
                 limit=limit,
             )
         else:

--- a/src/shmoney/config.py
+++ b/src/shmoney/config.py
@@ -13,6 +13,8 @@ class Config:
     db_path: Path
     opencorporates_api_token: str | None
     opencorporates_query: str
+    facebook_user_agent: str
+    facebook_seeds_file: Path
 
 
 def load_config() -> Config:
@@ -28,4 +30,11 @@ def load_config() -> Config:
         db_path=Path(os.environ.get("DB_PATH", "data/pipeline.db")),
         opencorporates_api_token=os.environ.get("OPENCORPORATES_API_TOKEN") or None,
         opencorporates_query=os.environ.get("OPENCORPORATES_QUERY", ""),
+        facebook_user_agent=os.environ.get(
+            "FACEBOOK_USER_AGENT",
+            "shmoney-scraper (contact: ops@example.com)",
+        ),
+        facebook_seeds_file=Path(
+            os.environ.get("FACEBOOK_SEEDS_FILE", "data/facebook_seeds.txt")
+        ),
     )

--- a/src/shmoney/sources/facebook.py
+++ b/src/shmoney/sources/facebook.py
@@ -1,0 +1,203 @@
+import json
+import logging
+import re
+import time
+import urllib.robotparser
+from typing import Callable, Iterable, Iterator, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from .base import RawBusiness, SourceAdapter
+
+
+log = logging.getLogger(__name__)
+
+
+class FacebookParseError(RuntimeError):
+    pass
+
+
+_OG_TITLE_RE = re.compile(
+    r'<meta\s+property=["\']og:title["\']\s+content=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+_OG_CATEGORY_RE = re.compile(
+    r'<meta\s+property=["\']og:description["\']\s+content=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+_JSON_LD_RE = re.compile(
+    r'<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _default_robots_allows(user_agent: str) -> Callable[[str], bool]:
+    cache: dict[str, urllib.robotparser.RobotFileParser] = {}
+
+    def _allows(url: str) -> bool:
+        parsed = urlparse(url)
+        root = f"{parsed.scheme}://{parsed.netloc}"
+        rp = cache.get(root)
+        if rp is None:
+            rp = urllib.robotparser.RobotFileParser()
+            rp.set_url(f"{root}/robots.txt")
+            try:
+                rp.read()
+            except Exception:
+                return False
+            cache[root] = rp
+        return rp.can_fetch(user_agent, url)
+
+    return _allows
+
+
+def _find_local_business(obj):
+    if isinstance(obj, dict):
+        t = obj.get("@type")
+        types = t if isinstance(t, list) else [t]
+        if any(isinstance(x, str) and "Business" in x for x in types):
+            return obj
+        for v in obj.values():
+            found = _find_local_business(v)
+            if found is not None:
+                return found
+    elif isinstance(obj, list):
+        for v in obj:
+            found = _find_local_business(v)
+            if found is not None:
+                return found
+    return None
+
+
+def _format_address(addr) -> str:
+    if not isinstance(addr, dict):
+        return ""
+    parts = [
+        addr.get("streetAddress"),
+        addr.get("addressLocality"),
+        addr.get("addressRegion"),
+        addr.get("postalCode"),
+    ]
+    return ", ".join(p for p in parts if p)
+
+
+def _parse_page(html: str, page_url: str) -> RawBusiness:
+    ld_block = None
+    for match in _JSON_LD_RE.finditer(html):
+        raw = match.group(1).strip()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        candidate = _find_local_business(data)
+        if candidate is not None:
+            ld_block = candidate
+            break
+
+    og_title_m = _OG_TITLE_RE.search(html)
+    og_desc_m = _OG_CATEGORY_RE.search(html)
+
+    name = None
+    if ld_block and ld_block.get("name"):
+        name = ld_block["name"]
+    elif og_title_m:
+        name = og_title_m.group(1)
+
+    if not name:
+        raise FacebookParseError(
+            f"could not extract business name from {page_url}; selectors may be stale"
+        )
+
+    address = _format_address(ld_block.get("address") if ld_block else None)
+    phone = ld_block.get("telephone") if ld_block else None
+    external = ld_block.get("url") if ld_block else None
+    category = None
+    if og_desc_m:
+        category = og_desc_m.group(1)
+    elif ld_block and ld_block.get("priceRange"):
+        category = None
+
+    website = external or page_url
+
+    return RawBusiness(
+        source="facebook",
+        name=name,
+        address=address,
+        phone=phone,
+        website=website,
+        business_type=category,
+        yelp_or_google_listing=page_url,
+        raw={"page_url": page_url, "ld": ld_block},
+    )
+
+
+class FacebookPagesAdapter(SourceAdapter):
+    source_name = "facebook"
+
+    def __init__(
+        self,
+        user_agent: str,
+        page_urls: Iterable[str],
+        client: Optional[httpx.Client] = None,
+        min_interval_s: float = 3.0,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        robots_allows: Optional[Callable[[str], bool]] = None,
+        limit: Optional[int] = None,
+    ):
+        if not user_agent:
+            raise ValueError("user_agent required")
+        self.user_agent = user_agent
+        self.page_urls = list(page_urls)
+        self.min_interval_s = min_interval_s
+        self._now = now
+        self._sleep = sleep
+        self._robots_allows = robots_allows or _default_robots_allows(user_agent)
+        self.limit = limit
+        if client is None:
+            client = httpx.Client(
+                headers={"User-Agent": user_agent},
+                timeout=15.0,
+                follow_redirects=True,
+            )
+        self._client = client
+
+    def iter_businesses(self) -> Iterator[RawBusiness]:
+        last_fetch_at: dict[str, float] = {}
+        denied_hosts: set[str] = set()
+        emitted = 0
+        for url in self.page_urls:
+            if self.limit is not None and emitted >= self.limit:
+                break
+            host = urlparse(url).netloc.lower()
+            if host in denied_hosts:
+                continue
+            if not self._robots_allows(url):
+                log.info("robots.txt disallow for host %s; skipping host", host)
+                denied_hosts.add(host)
+                continue
+
+            last = last_fetch_at.get(host)
+            if last is not None:
+                elapsed = self._now() - last
+                wait = self.min_interval_s - elapsed
+                if wait > 0:
+                    self._sleep(wait)
+            last_fetch_at[host] = self._now()
+
+            try:
+                resp = self._client.get(url, headers={"User-Agent": self.user_agent})
+            except httpx.HTTPError as e:
+                log.warning("fetch failed for %s: %s", url, e)
+                continue
+
+            if resp.status_code == 404:
+                log.info("facebook page 404/takedown: %s", url)
+                continue
+            if resp.status_code >= 400:
+                log.warning("facebook fetch %s returned %s", url, resp.status_code)
+                continue
+
+            yield _parse_page(resp.text, url)
+            emitted += 1

--- a/tests/test_facebook_adapter.py
+++ b/tests/test_facebook_adapter.py
@@ -1,0 +1,228 @@
+import httpx
+import pytest
+
+from shmoney.sources.facebook import FacebookPagesAdapter, FacebookParseError
+
+
+ACTIVE_PAGE_HTML = """
+<!doctype html>
+<html>
+<head>
+<meta property="og:title" content="Joe's Pizza Baltimore" />
+<meta property="og:type" content="business.business" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "Joe's Pizza Baltimore",
+  "telephone": "(410) 555-0100",
+  "url": "https://joespizzabmore.com",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Light St",
+    "addressLocality": "Baltimore",
+    "addressRegion": "MD",
+    "postalCode": "21230"
+  },
+  "priceRange": "$$"
+}
+</script>
+<meta property="og:description" content="Pizza & Italian" />
+</head>
+<body>Page body</body>
+</html>
+"""
+
+FB_ONLY_PAGE_HTML = """
+<!doctype html>
+<html><head>
+<meta property="og:title" content="Crab Shack" />
+<script type="application/ld+json">
+{"@type":"LocalBusiness","name":"Crab Shack",
+ "telephone":"410-555-0200",
+ "address":{"streetAddress":"9 Pier Rd","addressLocality":"Baltimore","addressRegion":"MD"}}
+</script>
+</head><body/></html>
+"""
+
+TAKEDOWN_HTML = "<html><body>This content isn't available right now</body></html>"
+
+
+def _transport_map(mapping: dict[str, httpx.Response]):
+    """Map URL -> Response. Unknown URLs 500."""
+
+    def handler(request):
+        url = str(request.url)
+        if url in mapping:
+            return mapping[url]
+        return httpx.Response(500, text=f"unexpected {url}")
+
+    return httpx.MockTransport(handler)
+
+
+def _client(mapping):
+    return httpx.Client(transport=_transport_map(mapping), headers={"User-Agent": "test"})
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        self.t += s
+
+
+def _allow_all(url: str) -> bool:
+    return True
+
+
+def _deny_all(url: str) -> bool:
+    return False
+
+
+def test_parses_active_page_with_external_website():
+    url = "https://www.facebook.com/joespizzabmore"
+    client = _client({url: httpx.Response(200, text=ACTIVE_PAGE_HTML)})
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="shmoney-scraper (contact: ops@example.com)",
+        page_urls=[url],
+        client=client,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_allow_all,
+    )
+    results = list(adapter.iter_businesses())
+    assert len(results) == 1
+    b = results[0]
+    assert b.source == "facebook"
+    assert b.name == "Joe's Pizza Baltimore"
+    assert "123 Light St" in b.address
+    assert "Baltimore" in b.address
+    assert b.phone == "(410) 555-0100"
+    assert b.website == "https://joespizzabmore.com"
+    assert b.yelp_or_google_listing == url
+
+
+def test_facebook_only_page_sets_website_to_fb_url():
+    url = "https://www.facebook.com/crabshack"
+    client = _client({url: httpx.Response(200, text=FB_ONLY_PAGE_HTML)})
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="ua",
+        page_urls=[url],
+        client=client,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_allow_all,
+    )
+    b = next(adapter.iter_businesses())
+    assert b.website == url  # so classifier tags social-only (facebook)
+
+
+def test_skips_404_takedown():
+    url = "https://www.facebook.com/gone"
+    client = _client({url: httpx.Response(404, text=TAKEDOWN_HTML)})
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="ua",
+        page_urls=[url],
+        client=client,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_allow_all,
+    )
+    assert list(adapter.iter_businesses()) == []
+
+
+def test_robots_disallow_skips_host_without_fetch(caplog):
+    url = "https://www.facebook.com/somebiz"
+    fetched: list[str] = []
+
+    def handler(request):
+        fetched.append(str(request.url))
+        return httpx.Response(200, text=ACTIVE_PAGE_HTML)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="ua",
+        page_urls=[url],
+        client=client,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_deny_all,
+    )
+    with caplog.at_level("INFO"):
+        assert list(adapter.iter_businesses()) == []
+    assert fetched == []
+    assert any("robots" in r.message.lower() for r in caplog.records)
+
+
+def test_rate_limit_sleeps_between_same_host_fetches():
+    url1 = "https://www.facebook.com/a"
+    url2 = "https://www.facebook.com/b"
+    client = _client(
+        {
+            url1: httpx.Response(200, text=ACTIVE_PAGE_HTML),
+            url2: httpx.Response(200, text=ACTIVE_PAGE_HTML),
+        }
+    )
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="ua",
+        page_urls=[url1, url2],
+        client=client,
+        min_interval_s=3.0,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_allow_all,
+    )
+    list(adapter.iter_businesses())
+    # first fetch: no sleep; second fetch on same host: sleep ~3s
+    assert len(clock.sleeps) == 1
+    assert clock.sleeps[0] == pytest.approx(3.0, abs=0.01)
+
+
+def test_parse_fails_loudly_when_name_missing():
+    url = "https://www.facebook.com/broken"
+    broken = "<html><head></head><body>no og, no json</body></html>"
+    client = _client({url: httpx.Response(200, text=broken)})
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="ua",
+        page_urls=[url],
+        client=client,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_allow_all,
+    )
+    with pytest.raises(FacebookParseError):
+        list(adapter.iter_businesses())
+
+
+def test_user_agent_sent_on_requests():
+    url = "https://www.facebook.com/withua"
+    seen: list[str] = []
+
+    def handler(request):
+        seen.append(request.headers.get("user-agent", ""))
+        return httpx.Response(200, text=ACTIVE_PAGE_HTML)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    clock = FakeClock()
+    adapter = FacebookPagesAdapter(
+        user_agent="shmoney-scraper (contact: ops@example.com)",
+        page_urls=[url],
+        client=client,
+        now=clock.now,
+        sleep=clock.sleep,
+        robots_allows=_allow_all,
+    )
+    list(adapter.iter_businesses())
+    assert seen == ["shmoney-scraper (contact: ops@example.com)"]


### PR DESCRIPTION
## Summary
- New `FacebookPagesAdapter` (`src/shmoney/sources/facebook.py`) iterates Page URLs, fetches public HTML, parses name/address/phone/category/external-website from JSON-LD + og tags.
- Per-host `urllib.robotparser` check before first fetch; disallowed hosts skipped with log entry and never re-queried.
- Per-host rate limit (default 1 req / 3 s, single-threaded) via injectable `now`/`sleep` for deterministic tests.
- User-Agent identifies operator + contact email (configurable via `FACEBOOK_USER_AGENT` env var).
- Parser fails loudly (`FacebookParseError`) when a 200 response lacks a recoverable business name — brittleness surfaces instead of emitting empty rows.
- When a page has no external website, `website` is set to the Facebook URL so the classifier tags the row `social-only (facebook)`.
- CLI: `pipeline run --source facebook --limit 10` reads Page URLs from `data/facebook_seeds.txt` (override via `FACEBOOK_SEEDS_FILE`). Seed-query discovery grid is intentionally out of scope for v1 — seed file is hand-populated.
- 7 fixture tests: happy-path active page, FB-only page, 404 takedown, robots disallow (asserts no fetch), rate-limit sleep on same host, loud-fail parse, UA header sent.

## Closes
#6

## Human QA steps
- [x] Create `data/facebook_seeds.txt` with 2–3 real public Baltimore Page URLs (one per line).
- [ ] Run `pipeline run --source facebook --limit 2` and confirm up to 2 rows upserted to the Sheet.
- [ ] For a Page with no external website, confirm the row's `Consulting Opportunity` column reads `social-only (facebook)`.
- [ ] For a Page whose HTML exposes an external website in JSON-LD, confirm that URL lands in the `Website URL` column and the row is scored by `WebsiteAuditor`.
- [ ] Edge case: add a URL for a host whose `/robots.txt` disallows the UA and confirm it's skipped with an `INFO` log line mentioning `robots`.
- [ ] Edge case: add a URL pointing at a deleted Page (404) and confirm the run continues and emits 0 rows for that URL.
- [ ] Timing: add two URLs on the same host and confirm the second fetch is delayed by ~3 s (visible in clock time between log lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)