### PR TITLE
feat: add Baltimore City MBE/WBE license adapter

### DIFF
--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -5,6 +5,7 @@ from .config import load_config
 from .orchestrator import run_once
 from .repo import Repository
 from .sheets import SheetsWriter
+from .sources.baltimore_city import BaltimoreCityLicenseAdapter
 from .sources.opencorporates import OpenCorporatesMDAdapter
 from .sources.yelp import YelpFusionAdapter
 
@@ -74,6 +75,12 @@ def run(
                 api_token=cfg.opencorporates_api_token,
                 query=cfg.opencorporates_query or term,
                 limit=limit,
+            )
+        elif source == "baltimore-city":
+            adapter = BaltimoreCityLicenseAdapter(limit=limit)
+        elif source in {"harford", "carroll"}:
+            raise typer.BadParameter(
+                f"source {source!r} has no public license feed — see docs/license-sources.md"
             )
         else:
             raise typer.BadParameter(f"source {source!r} not implemented")

--- a/src/shmoney/sources/baltimore_city.py
+++ b/src/shmoney/sources/baltimore_city.py
@@ -1,0 +1,114 @@
+import time
+from typing import Callable, Iterator, Optional
+
+import httpx
+
+from .base import RawBusiness, SourceAdapter
+
+
+FEATURE_SERVICE_BASE = "https://services1.arcgis.com"
+QUERY_PATH = (
+    "/UWYHeuuJISiGmgXx/arcgis/rest/services/MBWOO_Geocoded/FeatureServer/0/query"
+)
+
+
+def _compose_address(a: dict) -> str:
+    street = (a.get("user_streetaddress") or "").strip()
+    city = (a.get("user_city") or "").strip()
+    state = (a.get("user_state") or "").strip()
+    zipc = (a.get("user_zipcode") or "").strip().rstrip("-")
+    tail = " ".join(p for p in [state, zipc] if p)
+    parts = [street, city, tail]
+    return ", ".join(p for p in parts if p)
+
+
+def _compose_owner(a: dict) -> Optional[str]:
+    first = (a.get("user_firstname") or "").strip()
+    last = (a.get("user_lastname") or "").strip()
+    name = " ".join(p for p in [first, last] if p)
+    return name or None
+
+
+def _clean_website(value) -> Optional[str]:
+    if not value:
+        return None
+    v = str(value).strip()
+    if not v or v.upper() == "NULL":
+        return None
+    return v
+
+
+class BaltimoreCityLicenseAdapter(SourceAdapter):
+    source_name = "baltimore-city-license"
+
+    def __init__(
+        self,
+        client: Optional[httpx.Client] = None,
+        page_size: int = 1000,
+        limit: Optional[int] = None,
+        min_interval_s: float = 0.5,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        self.page_size = page_size
+        self.limit = limit
+        self.min_interval_s = min_interval_s
+        self._now = now
+        self._sleep = sleep
+        if client is None:
+            client = httpx.Client(base_url=FEATURE_SERVICE_BASE, timeout=30.0)
+        self._client = client
+
+    def iter_businesses(self) -> Iterator[RawBusiness]:
+        emitted = 0
+        offset = 0
+        last_fetch_at: Optional[float] = None
+
+        while True:
+            if self.limit is not None and emitted >= self.limit:
+                return
+
+            if last_fetch_at is not None:
+                elapsed = self._now() - last_fetch_at
+                wait = self.min_interval_s - elapsed
+                if wait > 0:
+                    self._sleep(wait)
+
+            params = {
+                "where": "1=1",
+                "outFields": "*",
+                "f": "json",
+                "resultOffset": str(offset),
+                "resultRecordCount": str(self.page_size),
+            }
+            resp = self._client.get(QUERY_PATH, params=params)
+            last_fetch_at = self._now()
+            resp.raise_for_status()
+            payload = resp.json()
+
+            features = payload.get("features", [])
+            if not features:
+                return
+
+            for feat in features:
+                if self.limit is not None and emitted >= self.limit:
+                    return
+                a = feat.get("attributes", {})
+                if (a.get("user_contractstatus") or "").strip().upper() != "CERTIFY":
+                    continue
+                yield RawBusiness(
+                    source=self.source_name,
+                    name=(a.get("user_company") or "").strip(),
+                    address=_compose_address(a),
+                    phone=a.get("user_phone") or None,
+                    website=_clean_website(a.get("user_website")),
+                    business_type=a.get("user_category") or None,
+                    owner_name=_compose_owner(a),
+                    registered_at=a.get("user_origcert") or None,
+                    raw=a,
+                )
+                emitted += 1
+
+            if not payload.get("exceededTransferLimit"):
+                return
+            offset += len(features)

--- a/tests/test_baltimore_city_adapter.py
+++ b/tests/test_baltimore_city_adapter.py
@@ -1,0 +1,178 @@
+import httpx
+
+from shmoney.sources.baltimore_city import BaltimoreCityLicenseAdapter
+
+
+BASE_URL = "https://services1.arcgis.com"
+QUERY_PATH = "/UWYHeuuJISiGmgXx/arcgis/rest/services/MBWOO_Geocoded/FeatureServer/0/query"
+
+
+def _client(handler):
+    return httpx.Client(base_url=BASE_URL, transport=httpx.MockTransport(handler))
+
+
+def _feature(**attrs):
+    return {"attributes": attrs}
+
+
+def _query_response(features, exceeded=False):
+    return {"features": features, "exceededTransferLimit": exceeded}
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        self.t += s
+
+
+def _sample_attrs(**overrides):
+    base = {
+        "user_company": "Noble's Landscape Service",
+        "user_firstname": "Jay",
+        "user_lastname": "Noble",
+        "user_streetaddress": "3314 Elgin Avenue",
+        "user_city": "Baltimore",
+        "user_state": "Md",
+        "user_zipcode": "21216-",
+        "user_phone": "(410)233-4915",
+        "user_website": "NULL",
+        "user_category": "SERVICES",
+        "user_origcert": "2000-01-16T00:00:00",
+        "user_contractstatus": "CERTIFY",
+        "user_contracttype": "MBE",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parses_feature_into_raw_business():
+    def handler(request):
+        assert request.url.path == QUERY_PATH
+        return httpx.Response(200, json=_query_response([_feature(**_sample_attrs())]))
+
+    adapter = BaltimoreCityLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    results = list(adapter.iter_businesses())
+
+    assert len(results) == 1
+    b = results[0]
+    assert b.source == "baltimore-city-license"
+    assert b.name == "Noble's Landscape Service"
+    assert b.owner_name == "Jay Noble"
+    assert "3314 Elgin Avenue" in b.address
+    assert "Baltimore" in b.address
+    assert "21216" in b.address
+    assert b.phone == "(410)233-4915"
+    assert b.registered_at == "2000-01-16T00:00:00"
+    assert b.business_type == "SERVICES"
+
+
+def test_null_website_treated_as_none():
+    def handler(request):
+        return httpx.Response(200, json=_query_response([
+            _feature(**_sample_attrs(user_website="NULL"))
+        ]))
+
+    adapter = BaltimoreCityLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    b = next(adapter.iter_businesses())
+    assert b.website is None
+
+
+def test_real_website_preserved():
+    def handler(request):
+        return httpx.Response(200, json=_query_response([
+            _feature(**_sample_attrs(user_website="https://example.com"))
+        ]))
+
+    adapter = BaltimoreCityLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    b = next(adapter.iter_businesses())
+    assert b.website == "https://example.com"
+
+
+def test_skips_inactive_certifications():
+    def handler(request):
+        return httpx.Response(200, json=_query_response([
+            _feature(**_sample_attrs(user_company="Active Co", user_contractstatus="CERTIFY")),
+            _feature(**_sample_attrs(user_company="Closed Co", user_contractstatus="CLOSED")),
+            _feature(**_sample_attrs(user_company="Expired Co", user_contractstatus="EXPIRED")),
+        ]))
+
+    adapter = BaltimoreCityLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    names = [b.name for b in adapter.iter_businesses()]
+    assert names == ["Active Co"]
+
+
+def test_paginates_until_no_more_records():
+    pages: list[int] = []
+
+    def handler(request):
+        offset = int(request.url.params.get("resultOffset", "0"))
+        pages.append(offset)
+        if offset == 0:
+            feats = [_feature(**_sample_attrs(user_company=f"Biz A{i}")) for i in range(2)]
+            return httpx.Response(200, json=_query_response(feats, exceeded=True))
+        if offset == 2:
+            feats = [_feature(**_sample_attrs(user_company=f"Biz B{i}")) for i in range(1)]
+            return httpx.Response(200, json=_query_response(feats, exceeded=False))
+        return httpx.Response(200, json=_query_response([]))
+
+    adapter = BaltimoreCityLicenseAdapter(
+        client=_client(handler), page_size=2, min_interval_s=0.0
+    )
+    results = list(adapter.iter_businesses())
+    assert [b.name for b in results] == ["Biz A0", "Biz A1", "Biz B0"]
+    assert pages == [0, 2]
+
+
+def test_limit_respected():
+    def handler(request):
+        feats = [_feature(**_sample_attrs(user_company=f"Biz {i}")) for i in range(50)]
+        return httpx.Response(200, json=_query_response(feats, exceeded=True))
+
+    adapter = BaltimoreCityLicenseAdapter(
+        client=_client(handler), limit=3, page_size=50, min_interval_s=0.0
+    )
+    results = list(adapter.iter_businesses())
+    assert len(results) == 3
+
+
+def test_rate_limit_sleeps_between_pages():
+    def handler(request):
+        offset = int(request.url.params.get("resultOffset", "0"))
+        if offset == 0:
+            return httpx.Response(200, json=_query_response(
+                [_feature(**_sample_attrs())], exceeded=True
+            ))
+        return httpx.Response(200, json=_query_response([]))
+
+    clock = FakeClock()
+    adapter = BaltimoreCityLicenseAdapter(
+        client=_client(handler),
+        page_size=1,
+        min_interval_s=0.5,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    list(adapter.iter_businesses())
+    assert clock.sleeps == [0.5]
+
+
+def test_sends_expected_query_params():
+    captured = []
+
+    def handler(request):
+        captured.append(request)
+        return httpx.Response(200, json=_query_response([]))
+
+    adapter = BaltimoreCityLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    list(adapter.iter_businesses())
+    req = captured[0]
+    assert req.url.params["where"] == "1=1"
+    assert req.url.params["outFields"] == "*"
+    assert req.url.params["f"] == "json"


### PR DESCRIPTION
## Summary
- New `BaltimoreCityLicenseAdapter` reads from the Baltimore City ArcGIS FeatureServer (MBWOO_Geocoded layer — Minority/Women Business Enterprise certifications) and emits `RawBusiness` rows with owner name, address, phone, registration date, and category.
- Filters to active `user_contractstatus == "CERTIFY"` (skips CLOSED/EXPIRED).
- Paginates via `resultOffset` + `exceededTransferLimit` with injectable rate limiter (default 2 req/s).
- Wires `pipeline run --source baltimore-city` in the CLI.
- Adds loud `BadParameter` for `--source harford` / `--source carroll` (per deferral in `docs/license-sources.md`, which ships in PR #16).
- 8 new unit tests via `httpx.MockTransport`; full suite still 77 green.

## Closes
#7 (Phase B — first jurisdiction adapter; follow-up PRs will add Howard then extract `LicenseAdapterBase`)

## Human QA steps
- [x] Run `pipeline run --source baltimore-city --limit 5`. Expect `upserted 5 rows` and 5 rows visible in the Sheet with Owner Name populated (e.g. "Jay Noble" for "Noble's Landscape Service").
- [ ] Run `pipeline run --source yelp --location "Baltimore, MD" --term "landscaping" --limit 20` and confirm any row whose name+address canonicalizes to a Baltimore City MBE cert now has Owner Name filled in (join via `repo.upsert_business` COALESCE).
- [ ] Run `pipeline run --source harford`. Expect exit with `Error: source 'harford' has no public license feed — see docs/license-sources.md` (not silent 0 rows).
- [ ] Edge case: set `--limit 1` and confirm exactly one row is emitted even though the ArcGIS page_size default is 1000 (limit check runs inside the feature loop).
- [ ] Edge case: pick an MBE record with `user_website` set to `"NULL"` in the raw feed and confirm the Sheet row shows an empty website (not the literal string `NULL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)