### PR TITLE
feat: add Howard County license adapter + LicenseAdapterBase

### DIFF
--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -5,6 +5,7 @@ from .config import load_config
 from .orchestrator import run_once
 from .repo import Repository
 from .sheets import SheetsWriter
+from .sources.howard import HowardLicenseAdapter
 from .sources.opencorporates import OpenCorporatesMDAdapter
 from .sources.yelp import YelpFusionAdapter
 
@@ -74,6 +75,12 @@ def run(
                 api_token=cfg.opencorporates_api_token,
                 query=cfg.opencorporates_query or term,
                 limit=limit,
+            )
+        elif source == "howard":
+            adapter = HowardLicenseAdapter(limit=limit)
+        elif source in {"harford", "carroll"}:
+            raise typer.BadParameter(
+                f"source {source!r} has no public license feed — see docs/license-sources.md"
             )
         else:
             raise typer.BadParameter(f"source {source!r} not implemented")

--- a/src/shmoney/sources/howard.py
+++ b/src/shmoney/sources/howard.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+import httpx
+
+from .base import RawBusiness
+from .license_base import LicenseAdapterBase
+
+
+PORTAL_BASE = "https://opendata.howardcountymd.gov"
+LIQUOR_LICENSE_RESOURCE = "/resource/tk3t-mn7e.json"
+
+
+class HowardLicenseAdapter(LicenseAdapterBase):
+    source_name = "howard-license"
+
+    def __init__(
+        self,
+        resource_path: str = LIQUOR_LICENSE_RESOURCE,
+        app_token: Optional[str] = None,
+        **kwargs,
+    ):
+        self.resource_path = resource_path
+        self.app_token = app_token
+        super().__init__(**kwargs)
+        if app_token:
+            self._client.headers["X-App-Token"] = app_token
+
+    def _build_default_client(self) -> httpx.Client:
+        headers = {"X-App-Token": self.app_token} if self.app_token else {}
+        return httpx.Client(base_url=PORTAL_BASE, headers=headers, timeout=30.0)
+
+    def _fetch_page(self, offset: int) -> tuple[list[dict], bool]:
+        params = {"$limit": str(self.page_size), "$offset": str(offset)}
+        resp = self._client.get(self.resource_path, params=params)
+        resp.raise_for_status()
+        records = resp.json()
+        has_more = len(records) >= self.page_size
+        return records, has_more
+
+    def _to_raw_business(self, rec: dict) -> Optional[RawBusiness]:
+        trade = (rec.get("trade_name") or "").strip()
+        corp = (rec.get("corp_name") or "").strip()
+        name = trade or corp
+        if not name:
+            return None
+        return RawBusiness(
+            source=self.source_name,
+            name=name,
+            address=(rec.get("address") or "").strip(),
+            owner_name=corp or None,
+            business_type=(rec.get("description") or "").strip() or None,
+            raw=rec,
+        )

--- a/src/shmoney/sources/license_base.py
+++ b/src/shmoney/sources/license_base.py
@@ -1,0 +1,83 @@
+import time
+from abc import abstractmethod
+from typing import Callable, Iterator, Optional
+
+import httpx
+
+from .base import RawBusiness, SourceAdapter
+
+
+class LicenseAdapterBase(SourceAdapter):
+    """Shared scaffold for paginated license-data adapters.
+
+    Subclasses override `_fetch_page(offset)` to return `(records, has_more)`
+    and `_to_raw_business(record)` to map one record (or skip by returning
+    None). The base owns the iteration loop, the `limit` cap, and the
+    per-request rate limiter. `now` and `sleep` are injectable so tests can
+    assert sleep durations without real clock waits.
+    """
+
+    default_page_size: int = 1000
+
+    def __init__(
+        self,
+        client: Optional[httpx.Client] = None,
+        page_size: Optional[int] = None,
+        limit: Optional[int] = None,
+        min_interval_s: float = 0.5,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        self.page_size = page_size if page_size is not None else self.default_page_size
+        self.limit = limit
+        self.min_interval_s = min_interval_s
+        self._now = now
+        self._sleep = sleep
+        self._client = client if client is not None else self._build_default_client()
+
+    @abstractmethod
+    def _build_default_client(self) -> httpx.Client:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _fetch_page(self, offset: int) -> tuple[list[dict], bool]:
+        """Return (records, has_more). Empty records ends iteration."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _to_raw_business(self, record: dict) -> Optional[RawBusiness]:
+        """Map one record. Return None to skip (filtered out)."""
+        raise NotImplementedError
+
+    def iter_businesses(self) -> Iterator[RawBusiness]:
+        emitted = 0
+        offset = 0
+        last_fetch_at: Optional[float] = None
+
+        while True:
+            if self.limit is not None and emitted >= self.limit:
+                return
+
+            if last_fetch_at is not None:
+                wait = self.min_interval_s - (self._now() - last_fetch_at)
+                if wait > 0:
+                    self._sleep(wait)
+
+            records, has_more = self._fetch_page(offset)
+            last_fetch_at = self._now()
+
+            if not records:
+                return
+
+            for rec in records:
+                if self.limit is not None and emitted >= self.limit:
+                    return
+                raw = self._to_raw_business(rec)
+                if raw is None:
+                    continue
+                yield raw
+                emitted += 1
+
+            if not has_more:
+                return
+            offset += len(records)

--- a/tests/test_howard_adapter.py
+++ b/tests/test_howard_adapter.py
@@ -1,0 +1,151 @@
+import httpx
+
+from shmoney.sources.howard import HowardLicenseAdapter
+
+
+BASE_URL = "https://opendata.howardcountymd.gov"
+RESOURCE_PATH = "/resource/tk3t-mn7e.json"
+
+
+def _client(handler):
+    return httpx.Client(base_url=BASE_URL, transport=httpx.MockTransport(handler))
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        self.t += s
+
+
+def _sample(**overrides):
+    base = {
+        "license_class": "B",
+        "description": "Beer, Wine and Liquor",
+        "corp_name": "Ruma, Inc.",
+        "trade_name": "Curry & Kabob",
+        "address": "10451 Twin Rivers Road, #132, Columbia MD 21044",
+    }
+    base.update(overrides)
+    return base
+
+
+def _once(records):
+    def handler(request):
+        assert request.url.path == RESOURCE_PATH
+        offset = int(request.url.params.get("$offset", "0"))
+        return httpx.Response(200, json=records if offset == 0 else [])
+    return handler
+
+
+def test_parses_record_into_raw_business():
+    def handler(request):
+        assert request.url.path == RESOURCE_PATH
+        offset = int(request.url.params.get("$offset", "0"))
+        return httpx.Response(200, json=[_sample()] if offset == 0 else [])
+
+    adapter = HowardLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    results = list(adapter.iter_businesses())
+
+    assert len(results) == 1
+    b = results[0]
+    assert b.source == "howard-license"
+    assert b.name == "Curry & Kabob"
+    assert b.owner_name == "Ruma, Inc."
+    assert b.address == "10451 Twin Rivers Road, #132, Columbia MD 21044"
+    assert b.business_type == "Beer, Wine and Liquor"
+
+
+def test_falls_back_to_corp_name_when_no_trade_name():
+    adapter = HowardLicenseAdapter(
+        client=_client(_once([_sample(trade_name="", corp_name="Solo LLC")])),
+        min_interval_s=0.0,
+    )
+    b = next(adapter.iter_businesses())
+    assert b.name == "Solo LLC"
+
+
+def test_paginates_via_offset_until_empty_page():
+    pages: list[int] = []
+
+    def handler(request):
+        offset = int(request.url.params.get("$offset", "0"))
+        pages.append(offset)
+        if offset == 0:
+            return httpx.Response(200, json=[_sample(trade_name=f"A{i}") for i in range(2)])
+        if offset == 2:
+            return httpx.Response(200, json=[_sample(trade_name="B0")])
+        return httpx.Response(200, json=[])
+
+    adapter = HowardLicenseAdapter(
+        client=_client(handler), page_size=2, min_interval_s=0.0
+    )
+    results = list(adapter.iter_businesses())
+    assert [b.name for b in results] == ["A0", "A1", "B0"]
+    assert pages == [0, 2]
+
+
+def test_limit_respected():
+    adapter = HowardLicenseAdapter(
+        client=_client(_once([_sample(trade_name=f"Biz {i}") for i in range(50)])),
+        limit=3,
+        page_size=50,
+        min_interval_s=0.0,
+    )
+    results = list(adapter.iter_businesses())
+    assert len(results) == 3
+
+
+def test_rate_limit_sleeps_between_pages():
+    def handler(request):
+        offset = int(request.url.params.get("$offset", "0"))
+        if offset == 0:
+            return httpx.Response(200, json=[_sample()])
+        return httpx.Response(200, json=[])
+
+    clock = FakeClock()
+    adapter = HowardLicenseAdapter(
+        client=_client(handler),
+        page_size=1,
+        min_interval_s=0.5,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    list(adapter.iter_businesses())
+    assert clock.sleeps == [0.5]
+
+
+def test_sends_limit_and_offset_params():
+    captured = []
+
+    def handler(request):
+        captured.append(request)
+        return httpx.Response(200, json=[])
+
+    adapter = HowardLicenseAdapter(
+        client=_client(handler), page_size=500, min_interval_s=0.0
+    )
+    list(adapter.iter_businesses())
+    req = captured[0]
+    assert req.url.params["$limit"] == "500"
+    assert req.url.params["$offset"] == "0"
+
+
+def test_sends_app_token_when_provided():
+    captured = []
+
+    def handler(request):
+        captured.append(request)
+        return httpx.Response(200, json=[])
+
+    adapter = HowardLicenseAdapter(
+        client=_client(handler), app_token="tok123", min_interval_s=0.0
+    )
+    list(adapter.iter_businesses())
+    assert captured[0].headers.get("X-App-Token") == "tok123"


### PR DESCRIPTION
## Summary
- New `HowardLicenseAdapter` reads Howard County's Socrata liquor-license dataset (`tk3t-mn7e`) and emits `RawBusiness` rows — `trade_name` → `name`, `corp_name` → `owner_name`, `description` → `business_type`. Supports Socrata `X-App-Token` headers.
- Extracts `LicenseAdapterBase` (`src/shmoney/sources/license_base.py`) owning the paginated-fetch loop, rate limiter (injectable clock), and `limit` cap. Subclasses implement `_fetch_page(offset)` and `_to_raw_business(record)` — nothing else required.
- Wires `pipeline run --source howard` in the CLI. `harford`/`carroll` continue to raise loud `BadParameter`.
- 7 new unit tests via `httpx.MockTransport`; full suite 76 green.

## Follow-up

Once PR #17 (Baltimore City) merges, a follow-up PR will migrate `BaltimoreCityLicenseAdapter` onto `LicenseAdapterBase`. Kept out of this PR to avoid bloating the diff and cross-branch coupling.

## Closes
#7 (Phase C — second jurisdiction adapter + shared base)

## Human QA steps
- [ ] Run `pipeline run --source howard --limit 5`. Expect `upserted 5 rows`, with Sheet rows showing `Curry & Kabob` / owner `Ruma, Inc.` (or similar) and business_type populated (e.g. `Beer, Wine and Liquor`).
- [ ] Run with `--limit 1` and confirm exactly one row is emitted (limit check lives in the base class now — ensures the extracted loop honors it).
- [ ] Run `pipeline run --source carroll`. Expect `Error: source 'carroll' has no public license feed — see docs/license-sources.md`.
- [ ] Edge case: seed a Yelp row in Baltimore whose canonical name+address matches a Howard liquor-license record (unlikely but possible) and confirm the Sheet row gets Owner Name filled in via `repo.upsert_business` COALESCE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)