### PR TITLE
fix: normalize street suffixes and zip in canonical_key

### DIFF
--- a/src/shmoney/canonicalize.py
+++ b/src/shmoney/canonicalize.py
@@ -7,14 +7,43 @@ _SUFFIX_RE = re.compile(
 )
 _NON_ALNUM = re.compile(r"[^a-z0-9 ]+")
 
+_STREET_SUFFIX_MAP = {
+    "avenue": "ave",
+    "boulevard": "blvd",
+    "court": "ct",
+    "drive": "dr",
+    "highway": "hwy",
+    "lane": "ln",
+    "parkway": "pkwy",
+    "place": "pl",
+    "road": "rd",
+    "street": "st",
+    "suite": "ste",
+    "apartment": "apt",
+    "number": "",
+    "unit": "ste",
+}
+_ZIP_DASH_RE = re.compile(r"\b(\d{5})-(?=\s|$)")
 
-def _normalize(s: str) -> str:
+
+def _normalize_name(s: str) -> str:
     s = (s or "").lower()
     s = _SUFFIX_RE.sub("", s)
     s = _NON_ALNUM.sub(" ", s)
     return " ".join(s.split())
 
 
+def _normalize_address(s: str) -> str:
+    s = (s or "").lower()
+    s = _ZIP_DASH_RE.sub(r"\1", s)
+    s = s.replace("#", " ste ")
+    s = _NON_ALNUM.sub(" ", s)
+    tokens = s.split()
+    tokens = [_STREET_SUFFIX_MAP.get(t, t) for t in tokens]
+    tokens = [t for t in tokens if t]
+    return " ".join(tokens)
+
+
 def canonical_key(name: str, address: str) -> str:
-    basis = f"{_normalize(name)}|{_normalize(address)}"
+    basis = f"{_normalize_name(name)}|{_normalize_address(address)}"
     return hashlib.sha1(basis.encode("utf-8")).hexdigest()

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -41,3 +41,40 @@ def test_key_is_sha1_hex():
     k = canonical_key("Joe's", "1 Main")
     assert len(k) == 40
     assert all(c in "0123456789abcdef" for c in k)
+
+
+def test_street_suffix_normalized():
+    assert canonical_key("Noble", "3314 Elgin Avenue") == canonical_key(
+        "Noble", "3314 Elgin Ave"
+    )
+    assert canonical_key("Biz", "1 Main Street") == canonical_key("Biz", "1 Main St")
+    assert canonical_key("Biz", "1 Park Road") == canonical_key("Biz", "1 Park Rd")
+    assert canonical_key("Biz", "1 Hill Boulevard") == canonical_key(
+        "Biz", "1 Hill Blvd"
+    )
+    assert canonical_key("Biz", "1 Oak Drive") == canonical_key("Biz", "1 Oak Dr")
+    assert canonical_key("Biz", "1 Elm Lane") == canonical_key("Biz", "1 Elm Ln")
+    assert canonical_key("Biz", "1 High Highway") == canonical_key("Biz", "1 High Hwy")
+
+
+def test_suite_and_hash_normalized():
+    assert canonical_key("Biz", "10451 Twin Rivers Rd, #132") == canonical_key(
+        "Biz", "10451 Twin Rivers Road Suite 132"
+    )
+    assert canonical_key("Biz", "1 Main St Apartment 2") == canonical_key(
+        "Biz", "1 Main St Apt 2"
+    )
+
+
+def test_trailing_zip_dash_stripped():
+    assert canonical_key("Biz", "1 Main St, Baltimore MD 21216-") == canonical_key(
+        "Biz", "1 Main St, Baltimore MD 21216"
+    )
+
+
+def test_name_does_not_get_address_suffix_collapse():
+    # A business literally named "Avenue Cafe" must not collapse to "Ave Cafe".
+    # If it did, "Avenue Cafe" at 1 Main St would collide with "Ave Cafe".
+    assert canonical_key("Avenue Cafe", "1 Main St") != canonical_key(
+        "Ave Cafe", "1 Main St"
+    )


### PR DESCRIPTION
## Summary
- `_normalize_address` now maps street suffixes (Avenue↔Ave, Street↔St, Road↔Rd, Boulevard↔Blvd, Drive↔Dr, Lane↔Ln, Highway↔Hwy, Court↔Ct, Parkway↔Pkwy, Place↔Pl), unit markers (Suite/Unit/#→Ste, Apartment→Apt), and strips the trailing-dash form of 5-digit zips.
- Names retain their original normalizer (no street-suffix collapse), so "Avenue Cafe" and "Ave Cafe" keep distinct keys.
- 4 new `test_canonicalize.py` tests; full suite 73 green.

## Why
QA on PR #17 ran Baltimore City MBE ingest then a Yelp landscaping search and expected at least one Owner Name to flow through the COALESCE join. Zero rows enriched. Read path is fine — orchestrator re-reads the merged business row from SQLite before writing to the Sheet. Root cause was the canonical key itself: MBE addresses carry full street words and trailing-dash zips (`"3314 Elgin Avenue, 21216-"`) while Yelp returns the USPS-short form (`"3314 Elgin Ave, 21216"`), so the two sources hashed to different keys and the COALESCE had no partner to merge with.

## Breaking-change note
Existing rows in `data/pipeline.db` were hashed with the old normalizer and will not match new rows under the new normalizer. Anyone relying on the join against pre-existing data must re-ingest the affected source. The Sheet is unaffected because the Sheet only updates the row it already wrote under its old key — new rows just land as new Sheet rows.

## Closes
Follows up PR #17 QA finding. No issue linked — tracked in the agile-leaping-teapot diagnosis plan.

## Human QA steps
- [ ] `pytest tests/test_canonicalize.py` green locally.
- [ ] After this and PR #17 both land, wipe `data/pipeline.db` and the Sheet, then run `pipeline run --source baltimore-city --limit 5` followed by `pipeline run --source yelp --location "Baltimore, MD" --term "janitorial" --limit 20` (janitorial overlaps MBE categories better than landscaping). If any MBE row and Yelp row share an address, expect the Sheet to show Owner Name populated on the merged row.
- [ ] Edge case: manually invoke `python -c "from shmoney.canonicalize import canonical_key; print(canonical_key('Noble', '3314 Elgin Avenue') == canonical_key('Noble', '3314 Elgin Ave'))"` — expect `True`.
- [ ] Negative edge case: `canonical_key("Avenue Cafe", "1 Main St") == canonical_key("Ave Cafe", "1 Main St")` — expect `False` (name path is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)