### PR TITLE
test: guard cross-source join with integration test + diag script

### DIFF
--- a/scripts/find_joins.py
+++ b/scripts/find_joins.py
@@ -1,0 +1,53 @@
+"""Scan pipeline.db for canonical keys that appear under >1 source.
+
+These are the rows where the license-to-business COALESCE join would fire.
+If this prints nothing, the Sheet showing no merged rows is expected — the
+data simply has no overlap at this key. If it prints matches but the Sheet
+doesn't reflect them, the bug is downstream of the key (orchestrator or
+Sheet writer).
+
+Usage:
+    python scripts/find_joins.py [path/to/pipeline.db]
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def find_cross_source_keys(db_path: Path) -> dict[str, set[str]]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT canonical_key, source FROM raw_fetches"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_key: dict[str, set[str]] = defaultdict(set)
+    for key, source in rows:
+        by_key[key].add(source)
+    return {k: s for k, s in by_key.items() if len(s) > 1}
+
+
+def main() -> int:
+    db_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/pipeline.db")
+    if not db_path.exists():
+        print(f"db not found: {db_path}", file=sys.stderr)
+        return 2
+
+    matches = find_cross_source_keys(db_path)
+    if not matches:
+        print("no cross-source canonical keys in raw_fetches")
+        return 0
+
+    print(f"{len(matches)} canonical key(s) seen under >1 source:")
+    for key, sources in sorted(matches.items()):
+        print(f"  {key}  {sorted(sources)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/shmoney/canonicalize.py
+++ b/src/shmoney/canonicalize.py
@@ -7,14 +7,43 @@ _SUFFIX_RE = re.compile(
 )
 _NON_ALNUM = re.compile(r"[^a-z0-9 ]+")
 
+_STREET_SUFFIX_MAP = {
+    "avenue": "ave",
+    "boulevard": "blvd",
+    "court": "ct",
+    "drive": "dr",
+    "highway": "hwy",
+    "lane": "ln",
+    "parkway": "pkwy",
+    "place": "pl",
+    "road": "rd",
+    "street": "st",
+    "suite": "ste",
+    "apartment": "apt",
+    "number": "",
+    "unit": "ste",
+}
+_ZIP_DASH_RE = re.compile(r"\b(\d{5})-(?=\s|$)")
 
-def _normalize(s: str) -> str:
+
+def _normalize_name(s: str) -> str:
     s = (s or "").lower()
     s = _SUFFIX_RE.sub("", s)
     s = _NON_ALNUM.sub(" ", s)
     return " ".join(s.split())
 
 
+def _normalize_address(s: str) -> str:
+    s = (s or "").lower()
+    s = _ZIP_DASH_RE.sub(r"\1", s)
+    s = s.replace("#", " ste ")
+    s = _NON_ALNUM.sub(" ", s)
+    tokens = s.split()
+    tokens = [_STREET_SUFFIX_MAP.get(t, t) for t in tokens]
+    tokens = [t for t in tokens if t]
+    return " ".join(tokens)
+
+
 def canonical_key(name: str, address: str) -> str:
-    basis = f"{_normalize(name)}|{_normalize(address)}"
+    basis = f"{_normalize_name(name)}|{_normalize_address(address)}"
     return hashlib.sha1(basis.encode("utf-8")).hexdigest()

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -41,3 +41,40 @@ def test_key_is_sha1_hex():
     k = canonical_key("Joe's", "1 Main")
     assert len(k) == 40
     assert all(c in "0123456789abcdef" for c in k)
+
+
+def test_street_suffix_normalized():
+    assert canonical_key("Noble", "3314 Elgin Avenue") == canonical_key(
+        "Noble", "3314 Elgin Ave"
+    )
+    assert canonical_key("Biz", "1 Main Street") == canonical_key("Biz", "1 Main St")
+    assert canonical_key("Biz", "1 Park Road") == canonical_key("Biz", "1 Park Rd")
+    assert canonical_key("Biz", "1 Hill Boulevard") == canonical_key(
+        "Biz", "1 Hill Blvd"
+    )
+    assert canonical_key("Biz", "1 Oak Drive") == canonical_key("Biz", "1 Oak Dr")
+    assert canonical_key("Biz", "1 Elm Lane") == canonical_key("Biz", "1 Elm Ln")
+    assert canonical_key("Biz", "1 High Highway") == canonical_key("Biz", "1 High Hwy")
+
+
+def test_suite_and_hash_normalized():
+    assert canonical_key("Biz", "10451 Twin Rivers Rd, #132") == canonical_key(
+        "Biz", "10451 Twin Rivers Road Suite 132"
+    )
+    assert canonical_key("Biz", "1 Main St Apartment 2") == canonical_key(
+        "Biz", "1 Main St Apt 2"
+    )
+
+
+def test_trailing_zip_dash_stripped():
+    assert canonical_key("Biz", "1 Main St, Baltimore MD 21216-") == canonical_key(
+        "Biz", "1 Main St, Baltimore MD 21216"
+    )
+
+
+def test_name_does_not_get_address_suffix_collapse():
+    # A business literally named "Avenue Cafe" must not collapse to "Ave Cafe".
+    # If it did, "Avenue Cafe" at 1 Main St would collide with "Ave Cafe".
+    assert canonical_key("Avenue Cafe", "1 Main St") != canonical_key(
+        "Ave Cafe", "1 Main St"
+    )

--- a/tests/test_find_joins_script.py
+++ b/tests/test_find_joins_script.py
@@ -1,0 +1,55 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from find_joins import find_cross_source_keys  # noqa: E402
+
+
+def _seed(db_path: Path, rows: list[tuple[str, str]]) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE raw_fetches (canonical_key TEXT, source TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO raw_fetches (canonical_key, source) VALUES (?, ?)", rows
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_reports_keys_with_multiple_sources(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(
+        db,
+        [
+            ("k1", "yelp"),
+            ("k1", "baltimore-city-license"),
+            ("k2", "yelp"),
+            ("k3", "howard-license"),
+            ("k3", "md-sdat"),
+        ],
+    )
+    result = find_cross_source_keys(db)
+    assert set(result.keys()) == {"k1", "k3"}
+    assert result["k1"] == {"yelp", "baltimore-city-license"}
+    assert result["k3"] == {"howard-license", "md-sdat"}
+
+
+def test_same_source_twice_is_not_a_join(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db, [("k1", "yelp"), ("k1", "yelp")])
+    assert find_cross_source_keys(db) == {}
+
+
+def test_empty_raw_fetches(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db, [])
+    assert find_cross_source_keys(db) == {}

--- a/tests/test_smoke_pipeline.py
+++ b/tests/test_smoke_pipeline.py
@@ -140,6 +140,40 @@ def test_sdat_merges_into_existing_yelp_row(tmp_path, fake_ws):
     assert int(row[_col("Years in Business")]) >= 5
 
 
+def test_join_fires_across_address_textual_variants(tmp_path, fake_ws):
+    # Regression for PR #17 QA: Yelp and license sources emit the same
+    # logical address in different textual forms ("Ave" vs "Avenue",
+    # trailing-dash zip). The COALESCE join must still merge them.
+    yelp_raw = RawBusiness(
+        source="yelp",
+        name="Noble's Landscape Service",
+        address="3314 Elgin Ave, Baltimore, MD 21216",
+        phone="410-555-0000",
+        website=None,
+    )
+    license_raw = RawBusiness(
+        source="baltimore-city-license",
+        name="Noble's Landscape Service",
+        address="3314 Elgin Avenue, Baltimore, MD 21216-",
+        owner_name="Jay Noble",
+        registered_at="2000-01-16",
+    )
+    repo = Repository(tmp_path / "t.db")
+    writer = SheetsWriter(fake_ws)
+
+    run_once(StubAdapter([yelp_raw], source_name="yelp"), repo, writer)
+    run_once(
+        StubAdapter([license_raw], source_name="baltimore-city-license"),
+        repo,
+        writer,
+    )
+
+    assert len(fake_ws.rows) == 2  # header + one merged row
+    row = fake_ws.rows[1]
+    assert row[_col("Owner Name")] == "Jay Noble"
+    assert row[_col("Phone Number")] == "410-555-0000"
+
+
 def test_rerun_does_not_duplicate(tmp_path, fake_ws):
     raw = RawBusiness(
         source="yelp",


### PR DESCRIPTION
## Summary
- New `test_smoke_pipeline.py::test_join_fires_across_address_textual_variants`: seeds a Yelp raw + a baltimore-city-license raw with the same logical address in different textual forms ("Ave" vs "Avenue", trailing-dash zip) and asserts the final Sheet row carries Owner Name. This is the test shape that would have caught PR #17's QA miss before ship.
- New `scripts/find_joins.py` + its own unit tests (3): reads `data/pipeline.db` and prints any `canonical_key` appearing in `raw_fetches` under >1 source. Answers "are there any join-eligible rows at all?" directly against the DB, instead of eyeballing the Sheet.
- 77 tests green (4 new).

## Why
PR #17 QA asked the operator to eyeball the Sheet for a merged Owner Name and got zero. The pipeline was actually correct on the write side — the bug was in canonical_key, fixed in PR #19. But there was no automated signal that the join even works end-to-end across realistic address strings, and no quick command to answer "is the Sheet result expected because there are zero matches, or is something broken?" — this PR adds both.

## Base branch
Stacked on `fix/canonical-key-address-normalization` (PR #19). The integration test relies on the address normalization landing there. Once #19 merges to `dev`, re-target this PR to `dev` or let the stacked merge flow handle it.

## Human QA steps
- [ ] `pytest tests/test_smoke_pipeline.py::test_join_fires_across_address_textual_variants` green locally.
- [ ] `pytest tests/test_find_joins_script.py` green locally (3 tests).
- [ ] Run `python scripts/find_joins.py` against your current `data/pipeline.db`. Expected today (pre-#19 merge and before any re-ingest) is `no cross-source canonical keys in raw_fetches`. After re-ingesting MBE + a Yelp search that overlaps in reality (e.g. `--term janitorial`), re-run the script and expect at least one match if any real business in the Yelp sample has an MBE cert.
- [ ] Pass a bogus path: `python scripts/find_joins.py /tmp/nope.db` — expect exit code 2 and `db not found: /tmp/nope.db` on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)