### PR TITLE
fix: do not populate owner_name with entity name in Howard adapter

### DIFF
--- a/src/shmoney/sources/howard.py
+++ b/src/shmoney/sources/howard.py
@@ -47,7 +47,6 @@ class HowardLicenseAdapter(LicenseAdapterBase):
             source=self.source_name,
             name=name,
             address=(rec.get("address") or "").strip(),
-            owner_name=corp or None,
             business_type=(rec.get("description") or "").strip() or None,
             raw=rec,
         )

--- a/tests/test_howard_adapter.py
+++ b/tests/test_howard_adapter.py
@@ -57,7 +57,10 @@ def test_parses_record_into_raw_business():
     b = results[0]
     assert b.source == "howard-license"
     assert b.name == "Curry & Kabob"
-    assert b.owner_name == "Ruma, Inc."
+    # owner_name is intentionally None — Howard's Socrata feed has no human
+    # owner, only the licensed entity. A later canonical_key join with
+    # OpenCorporates/MBE fills it in with a real person.
+    assert b.owner_name is None
     assert b.address == "10451 Twin Rivers Road, #132, Columbia MD 21044"
     assert b.business_type == "Beer, Wine and Liquor"
 


### PR DESCRIPTION
## Summary
- Howard adapter no longer sets `owner_name = corp_name`. Owner Name stays blank until a canonical_key join with a source that carries real human owners (OpenCorporates / Baltimore City MBE) fills it in.
- One test assertion updated accordingly.
- Phone is unchanged (already None) — Yelp/Google Places join is the correct fill path, not the Howard feed.
- 92 tests green.

## Why
QA on Howard showed the Owner Name column populated with "Ruma, Inc." — a legal entity, not a person. The Howard Socrata feed only carries `corp_name` and `trade_name`; there is no human owner field. Overloading `owner_name` with the entity is wrong on two counts: (1) it's misleading in the Sheet, and (2) it blocks the COALESCE join — a later run that brings a real human owner wouldn't overwrite the entity string already there.

## Future-join expectations
- Owner Name: will fill via `md-sdat` (OpenCorporates officer lookup) or `baltimore-city-license` (MBE `user_firstname`/`user_lastname`) when canonical_keys match.
- Phone: will fill via Yelp when canonical_keys match.

## Human QA steps
- [ ] `pipeline run --source howard --limit 5` → Sheet rows show empty Owner Name and empty Phone, but populated Business Type (`Beer, Wine and Liquor`) and Address.
- [ ] Run a Yelp query overlapping a Howard row's address (e.g. `--source yelp --location "Columbia, MD" --term restaurants --limit 20`). For any row that canonicalizes to the same key as a Howard record, confirm Phone appears in that Sheet row.
- [ ] `pytest tests/test_howard_adapter.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)