### PR TITLE
feat: Anne Arundel adapter + Baltimore City refactor (#7 Phase D)

### DIFF
--- a/docs/license-sources.md
+++ b/docs/license-sources.md
@@ -6,12 +6,12 @@ adapter now, defer, or fall back to a shared registry.
 
 | Jurisdiction | Portal | Platform | Business-license dataset | Status |
 | --- | --- | --- | --- | --- |
-| Baltimore City | `data.baltimorecity.gov` | Socrata | yes (search "business license" on the catalog — dataset ID to be confirmed during adapter build) | **build** |
-| Baltimore County | `opendata.baltimorecountymd.gov` | ArcGIS Hub | not confirmed — portal exists but licenses dataset presence is unverified | **verify, then build or defer** |
-| Anne Arundel | `opendata.aacounty.org` (ArcGIS) + `aacounty.org` license-search UI | ArcGIS / HTML | portal lists trade/amusement/bingo licenses via HTML search; no confirmed bulk dataset | **verify, likely HTML scrape** |
-| Howard | `opendata.howardcountymd.gov` | Socrata | partial: active electric/utility contractors, solicitors/peddlers, liquor licenses (2020 snapshot). No general business-license dataset. | **build (narrow: liquor + contractors)** |
-| Harford | none | — | no open-data portal; records only via MD Judiciary search UI or in-person | **defer (no public bulk feed)** |
-| Carroll | none | — | no open-data portal; records only via MD Judiciary search UI or FOIA | **defer (no public bulk feed)** |
+| Baltimore City | `data.baltimorecity.gov` | ArcGIS FeatureServer | MBE/WBE certifications (`MBWOO_Geocoded/0`) | **built** — `--source baltimore-city` |
+| Baltimore County | `opendata.baltimorecountymd.gov` | ArcGIS Hub | only "Rental License" (landlord-focused, not small-business leads); no business-license dataset | **deferred** |
+| Anne Arundel | `gis.aacounty.org` | ArcGIS FeatureServer | Liquor License Location (`Planning_aacoPZProd_OpenData/9`) | **built** — `--source anne-arundel` |
+| Howard | `opendata.howardcountymd.gov` | Socrata SODA | Liquor Licenses (`tk3t-mn7e`) | **built** — `--source howard` |
+| Harford | none | — | no open-data portal; MD Judiciary search UI only | **deferred** |
+| Carroll | none | — | no open-data portal; MD Judiciary search UI or FOIA only | **deferred** |
 
 ## Cross-cutting: Maryland Judiciary Business Licenses Online
 
@@ -38,20 +38,11 @@ reuses it by populating `owner_name` / `registered_at` on `RawBusiness`.
 
 #7 proceeds without #4.
 
-## Delivery plan
+## Delivery history
 
-1. **Phase B** (follow-up PR): Baltimore City adapter against
-   `data.baltimorecity.gov` Socrata API. Confirm dataset ID during build.
-2. **Phase C** (follow-up PR): Howard County adapter (liquor + contractors
-   datasets). Extract `LicenseAdapterBase` after the second adapter lands.
-3. **Phase D**: Baltimore County and Anne Arundel — build if the verification
-   step above turns up a real bulk dataset; otherwise defer alongside Harford
-   and Carroll.
-4. **Deferred jurisdictions** (Harford, Carroll, and anything that fails
-   verification): the CLI will expose `--source <name>` for them, and it must
-   raise a loud `BadParameter` pointing here. No silent 0-row runs.
+1. **Phase A** (PR #16): endpoint research + this document.
+2. **Phase B** (PR #17): `BaltimoreCityLicenseAdapter`.
+3. **Phase C** (PR #18): `HowardLicenseAdapter` + extracted `LicenseAdapterBase`.
+4. **Phase D** (this PR): `AnneArundelLicenseAdapter`; Baltimore County deferred (only feed is Rental License, not relevant to SMB lead-gen); `BaltimoreCityLicenseAdapter` refactored onto `LicenseAdapterBase`.
 
-## Not in scope for this PR
-
-Adapter code. This PR only records the research so the follow-up PRs can each
-target one confirmed endpoint.
+Deferred jurisdictions (`baltimore-county`, `harford`, `carroll`) all raise a loud `BadParameter` pointing here when invoked via `pipeline run --source <name>` — no silent 0-row runs.

--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -5,8 +5,9 @@ from .config import load_config
 from .orchestrator import run_once
 from .repo import Repository
 from .sheets import SheetsWriter
-from .sources.howard import HowardLicenseAdapter
+from .sources.anne_arundel import AnneArundelLicenseAdapter
 from .sources.baltimore_city import BaltimoreCityLicenseAdapter
+from .sources.howard import HowardLicenseAdapter
 from .sources.opencorporates import OpenCorporatesMDAdapter
 from .sources.yelp import YelpFusionAdapter
 
@@ -81,7 +82,9 @@ def run(
             adapter = HowardLicenseAdapter(limit=limit)
         elif source == "baltimore-city":
             adapter = BaltimoreCityLicenseAdapter(limit=limit)
-        elif source in {"harford", "carroll"}:
+        elif source == "anne-arundel":
+            adapter = AnneArundelLicenseAdapter(limit=limit)
+        elif source in {"harford", "carroll", "baltimore-county"}:
             raise typer.BadParameter(
                 f"source {source!r} has no public license feed — see docs/license-sources.md"
             )

--- a/src/shmoney/sources/anne_arundel.py
+++ b/src/shmoney/sources/anne_arundel.py
@@ -6,39 +6,31 @@ from .base import RawBusiness
 from .license_base import LicenseAdapterBase
 
 
-FEATURE_SERVICE_BASE = "https://services1.arcgis.com"
+FEATURE_SERVICE_BASE = "https://gis.aacounty.org"
 QUERY_PATH = (
-    "/UWYHeuuJISiGmgXx/arcgis/rest/services/MBWOO_Geocoded/FeatureServer/0/query"
+    "/arcgis/rest/services/OpenData/Planning_aacoPZProd_OpenData/FeatureServer/9/query"
 )
 
 
 def _compose_address(a: dict) -> str:
-    street = (a.get("user_streetaddress") or "").strip()
+    street = (a.get("user_street_address") or "").strip()
     city = (a.get("user_city") or "").strip()
-    state = (a.get("user_state") or "").strip()
-    zipc = (a.get("user_zipcode") or "").strip().rstrip("-")
+    state = (a.get("user_st") or "").strip()
+    zipc = (a.get("user_zip") or "").strip().split("-")[0]
     tail = " ".join(p for p in [state, zipc] if p)
     return ", ".join(p for p in [street, city, tail] if p)
 
 
-def _compose_owner(a: dict) -> Optional[str]:
-    first = (a.get("user_firstname") or "").strip()
-    last = (a.get("user_lastname") or "").strip()
-    name = " ".join(p for p in [first, last] if p)
-    return name or None
+class AnneArundelLicenseAdapter(LicenseAdapterBase):
+    """Anne Arundel County liquor license locations (ArcGIS feature service).
 
+    The feed carries only the licensed trade (DBA), address, and license
+    class. No human owner, no phone, no dates. `owner_name` is left None
+    so a later canonical_key join with OpenCorporates or Baltimore City
+    MBE can fill it in.
+    """
 
-def _clean_website(value) -> Optional[str]:
-    if not value:
-        return None
-    v = str(value).strip()
-    if not v or v.upper() == "NULL":
-        return None
-    return v
-
-
-class BaltimoreCityLicenseAdapter(LicenseAdapterBase):
-    source_name = "baltimore-city-license"
+    source_name = "anne-arundel-license"
 
     def _build_default_client(self) -> httpx.Client:
         return httpx.Client(base_url=FEATURE_SERVICE_BASE, timeout=30.0)
@@ -58,16 +50,13 @@ class BaltimoreCityLicenseAdapter(LicenseAdapterBase):
         return records, bool(payload.get("exceededTransferLimit"))
 
     def _to_raw_business(self, a: dict) -> Optional[RawBusiness]:
-        if (a.get("user_contractstatus") or "").strip().upper() != "CERTIFY":
+        name = (a.get("user_trade_name") or "").strip()
+        if not name:
             return None
         return RawBusiness(
             source=self.source_name,
-            name=(a.get("user_company") or "").strip(),
+            name=name,
             address=_compose_address(a),
-            phone=a.get("user_phone") or None,
-            website=_clean_website(a.get("user_website")),
-            business_type=a.get("user_category") or None,
-            owner_name=_compose_owner(a),
-            registered_at=a.get("user_origcert") or None,
+            business_type=(a.get("class") or "").strip() or None,
             raw=a,
         )

--- a/tests/test_anne_arundel_adapter.py
+++ b/tests/test_anne_arundel_adapter.py
@@ -1,0 +1,112 @@
+import httpx
+
+from shmoney.sources.anne_arundel import AnneArundelLicenseAdapter
+
+
+BASE_URL = "https://gis.aacounty.org"
+QUERY_PATH = (
+    "/arcgis/rest/services/OpenData/Planning_aacoPZProd_OpenData/FeatureServer/9/query"
+)
+
+
+def _client(handler):
+    return httpx.Client(base_url=BASE_URL, transport=httpx.MockTransport(handler))
+
+
+def _feature(**attrs):
+    return {"attributes": attrs}
+
+
+def _query_response(features, exceeded=False):
+    return {"features": features, "exceededTransferLimit": exceeded}
+
+
+def _sample(**overrides):
+    base = {
+        "user_trade_name": "Goldberg's Liquors",
+        "user_street_address": "5106 Ritchie Highway",
+        "user_city": "Baltimore",
+        "user_st": "MD",
+        "user_zip": "21225-3051",
+        "class": "A: Package Goods",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parses_feature_into_raw_business():
+    def handler(request):
+        assert request.url.path == QUERY_PATH
+        return httpx.Response(200, json=_query_response([_feature(**_sample())]))
+
+    adapter = AnneArundelLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    results = list(adapter.iter_businesses())
+
+    assert len(results) == 1
+    b = results[0]
+    assert b.source == "anne-arundel-license"
+    assert b.name == "Goldberg's Liquors"
+    assert "5106 Ritchie Highway" in b.address
+    assert "Baltimore" in b.address
+    assert "21225" in b.address
+    assert b.business_type == "A: Package Goods"
+    # No human owner in the AA feed — same stance as Howard.
+    assert b.owner_name is None
+
+
+def test_skips_records_without_trade_name():
+    def handler(request):
+        return httpx.Response(200, json=_query_response([
+            _feature(**_sample(user_trade_name="")),
+            _feature(**_sample(user_trade_name="Real Biz")),
+        ]))
+
+    adapter = AnneArundelLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    names = [b.name for b in adapter.iter_businesses()]
+    assert names == ["Real Biz"]
+
+
+def test_paginates_until_no_more_records():
+    pages: list[int] = []
+
+    def handler(request):
+        offset = int(request.url.params.get("resultOffset", "0"))
+        pages.append(offset)
+        if offset == 0:
+            feats = [_feature(**_sample(user_trade_name=f"Biz A{i}")) for i in range(2)]
+            return httpx.Response(200, json=_query_response(feats, exceeded=True))
+        return httpx.Response(200, json=_query_response([]))
+
+    adapter = AnneArundelLicenseAdapter(
+        client=_client(handler), page_size=2, min_interval_s=0.0
+    )
+    results = list(adapter.iter_businesses())
+    assert [b.name for b in results] == ["Biz A0", "Biz A1"]
+    assert pages == [0, 2]
+
+
+def test_limit_respected():
+    def handler(request):
+        feats = [_feature(**_sample(user_trade_name=f"Biz {i}")) for i in range(50)]
+        return httpx.Response(200, json=_query_response(feats, exceeded=True))
+
+    adapter = AnneArundelLicenseAdapter(
+        client=_client(handler), limit=3, page_size=50, min_interval_s=0.0
+    )
+    results = list(adapter.iter_businesses())
+    assert len(results) == 3
+
+
+def test_sends_expected_query_params():
+    captured = []
+
+    def handler(request):
+        captured.append(request)
+        return httpx.Response(200, json=_query_response([]))
+
+    adapter = AnneArundelLicenseAdapter(client=_client(handler), min_interval_s=0.0)
+    list(adapter.iter_businesses())
+    req = captured[0]
+    assert req.url.params["where"] == "1=1"
+    assert req.url.params["outFields"] == "*"
+    assert req.url.params["f"] == "json"


### PR DESCRIPTION
## Summary
- New `AnneArundelLicenseAdapter` reads Anne Arundel County's Liquor License Location ArcGIS feature service. Emits `RawBusiness` with `trade_name → name`, full address, license class → `business_type`. `owner_name=None` (no human field in the feed, same stance as Howard).
- Baltimore City adapter refactored onto `LicenseAdapterBase` — follow-up from PR #18. Behavior unchanged.
- CLI: `--source anne-arundel` wired. `--source baltimore-county` added to the deferred list alongside harford/carroll (only portal dataset is Rental License, landlord-focused, not SMB lead-gen).
- 97 tests green (5 new Anne Arundel adapter tests; Baltimore City tests unchanged and still pass after refactor).

## Closes #7

All six jurisdictions from the original scope now have a decision:

| Jurisdiction | Status |
| --- | --- |
| Baltimore City | built |
| Baltimore County | deferred (no SMB feed) |
| Anne Arundel | built (liquor) |
| Howard | built (liquor) |
| Harford | deferred (no feed) |
| Carroll | deferred (no feed) |

Deferred jurisdictions raise loud `BadParameter` via the CLI with a link to `docs/license-sources.md`.

## Human QA steps
- [ ] `pipeline run --source anne-arundel --limit 5` → `upserted 5 rows`; Sheet shows `Trade Name` in Business Name, liquor class (e.g. `A: Package Goods`) in Business Type, address populated, Owner Name blank.
- [ ] `pipeline run --source anne-arundel --limit 1` → exactly 1 new row.
- [ ] `pipeline run --source baltimore-county` → loud `BadParameter` pointing at `docs/license-sources.md`.
- [ ] `pipeline run --source baltimore-city --limit 5` → still works identically to pre-refactor (Owner Name populated with human first+last, Phone populated, Business Type populated).
- [ ] `pytest tests/test_baltimore_city_adapter.py tests/test_anne_arundel_adapter.py tests/test_howard_adapter.py` all green (verifies the base class doesn't regress any of the three subclasses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)