### PR TITLE
feat: SDAT Business Express enrichment adapter with ban-safe throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,36 @@ the last checkpointed offset. Successful runs clear the watermark.
 ```bash
 pipeline sheet-sync      # rebuild Sheet rows from SQLite (e.g. after an accidental delete)
 pipeline reset           # wipe SQLite only (not the Sheet). --yes skips the prompt.
+pipeline enrich          # fill Owner Name / formation date on existing rows via SDAT.
 ```
+
+## Enrichment (SDAT Business Express)
+
+`pipeline enrich --source md-sdat-direct` iterates `businesses WHERE owner_name
+IS NULL`, queries Maryland SDAT's public Business Express portal, and fills
+`owner_name` (officer for corporations, resident agent for LLCs) and
+`registered_at` via the existing COALESCE upsert. Hit rate is realistically
+30–45% — corporations are the reliable wins; sole proprietorships aren't in
+SDAT at all.
+
+Ban-avoidance defaults (intentionally conservative, not operator-configurable):
+- 4s min interval ± 1s jitter between requests.
+- Single-threaded, single session.
+- `robots.txt` consulted at init; refusal aborts the run.
+- 429 / challenge-page response = immediate `SdatCircuitBreakerOpen` abort,
+  watermark saved so next run resumes.
+- 5xx tolerated once with a 10s backoff; second failure aborts.
+- Every response cached to `data/sdat_cache/` — reruns never re-hit the portal.
+- `--limit` hard-capped at 200.
+
+```bash
+pipeline enrich --dry-run              # prints candidate list, zero network
+pipeline enrich --limit 25             # default; processes up to 25 rows
+```
+
+First-time use: capture a real search-results + detail HTML pair from the live
+portal and sanity-check that the parsers in `src/shmoney/sources/sdat_direct.py`
+find the expected field labels. Fixtures under `tests/` are synthetic.
 
 ## Diagnostics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Baltimore small business lead pipeline"
 requires-python = ">=3.11"
 dependencies = [
+    "beautifulsoup4>=4.12",
     "httpx>=0.27",
     "typer>=0.12",
     "gspread>=6.0",

--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -179,5 +179,97 @@ def reset(
     typer.echo("pipeline reset ok")
 
 
+_ENRICH_HARD_MAX = 200
+
+
+@app.command("enrich")
+def enrich_cmd(
+    source: str = typer.Option("md-sdat-direct", "--source"),
+    limit: int = typer.Option(25, "--limit"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+) -> None:
+    if source != "md-sdat-direct":
+        raise typer.BadParameter(
+            f"enrich source {source!r} not implemented"
+        )
+    limit = min(max(limit, 0), _ENRICH_HARD_MAX)
+    cfg = load_config()
+    repo = Repository(cfg.db_path)
+    try:
+        after = repo.get_text_watermark(source)
+        candidates = list(
+            repo.iter_businesses_missing_owner(limit=limit, after_key=after)
+        )
+        typer.echo(
+            f"[{source}] candidates={len(candidates)} limit={limit} "
+            f"resume_after={after!r} dry_run={dry_run}"
+        )
+        if dry_run:
+            for key, name, addr in candidates:
+                typer.echo(f"  DRY {key} name={name!r} addr={addr!r}")
+            return
+        if not candidates:
+            return
+
+        from .sources.sdat_direct import (
+            SdatCircuitBreakerOpen,
+            SdatEnricher,
+            pick_owner,
+        )
+        from .sources.base import RawBusiness
+        from dataclasses import asdict
+
+        enricher = SdatEnricher(
+            cache_dir=cfg.db_path.parent / "sdat_cache"
+        )
+        queried = matched = filled = skipped_dead = cache_hits = 0
+        aborted: str | None = None
+        try:
+            for key, name, addr in candidates:
+                queried += 1
+                try:
+                    rec = enricher.enrich(name, address_hint=addr)
+                except SdatCircuitBreakerOpen as e:
+                    aborted = str(e)
+                    typer.echo(f"  ABORT {key}: {aborted}")
+                    break
+                if rec is None:
+                    skipped_dead += 1
+                    typer.echo(f"  MISS {key} name={name!r}")
+                    continue
+                matched += 1
+                owner = pick_owner(rec)
+                if not owner:
+                    typer.echo(f"  NO-OWNER {key} legal={rec.legal_name!r}")
+                    repo.set_text_watermark(source, key)
+                    continue
+                raw = RawBusiness(
+                    source=source,
+                    name=name,
+                    address=addr,
+                    owner_name=owner,
+                    registered_at=rec.formation_date,
+                )
+                repo.record_raw(source, key, asdict(raw))
+                repo.upsert_business(key, raw)
+                repo.set_text_watermark(source, key)
+                filled += 1
+                typer.echo(
+                    f"  OK {key} owner={owner!r} formed={rec.formation_date}"
+                )
+        finally:
+            enricher.close()
+
+        typer.echo(
+            f"[{source}] queried={queried} matched={matched} "
+            f"owner_filled={filled} skipped={skipped_dead} "
+            f"cache_hits={cache_hits} aborted_on={aborted!r}"
+        )
+        if aborted:
+            raise typer.Exit(code=2)
+    finally:
+        repo.close()
+
+
 def main() -> None:
     app()

--- a/src/shmoney/repo.py
+++ b/src/shmoney/repo.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from .audit import AuditFlags, AuditReport
 from .sources.base import RawBusiness
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS sheet_row_map (
 CREATE TABLE IF NOT EXISTS source_watermarks (
     source TEXT PRIMARY KEY,
     cursor INTEGER NOT NULL DEFAULT 0,
+    cursor_text TEXT,
     last_run_ts TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -68,6 +69,17 @@ class Repository:
         self.conn = sqlite3.connect(str(self.db_path), isolation_level=None)
         self.conn.row_factory = sqlite3.Row
         self.conn.executescript(_SCHEMA)
+        self._migrate()
+
+    def _migrate(self) -> None:
+        # Idempotent: add cursor_text to source_watermarks if an older DB
+        # predates it. ALTER TABLE ADD COLUMN is safe on existing rows.
+        cols = {
+            row["name"]
+            for row in self.conn.execute("PRAGMA table_info(source_watermarks)")
+        }
+        if "cursor_text" not in cols:
+            self.conn.execute("ALTER TABLE source_watermarks ADD COLUMN cursor_text TEXT")
 
     def record_raw(self, source: str, canonical_key: str, payload: dict) -> None:
         self.conn.execute(
@@ -233,6 +245,43 @@ class Repository:
 
     def clear_watermark(self, source: str) -> None:
         self.conn.execute("DELETE FROM source_watermarks WHERE source = ?", (source,))
+
+    def get_text_watermark(self, source: str) -> Optional[str]:
+        row = self.conn.execute(
+            "SELECT cursor_text FROM source_watermarks WHERE source = ?", (source,)
+        ).fetchone()
+        return row["cursor_text"] if row else None
+
+    def set_text_watermark(self, source: str, cursor_text: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO source_watermarks (source, cursor, cursor_text) VALUES (?, 0, ?)
+            ON CONFLICT(source) DO UPDATE SET
+                cursor_text = excluded.cursor_text,
+                last_run_ts = CURRENT_TIMESTAMP
+            """,
+            (source, cursor_text),
+        )
+
+    def iter_businesses_missing_owner(
+        self,
+        limit: Optional[int] = None,
+        after_key: Optional[str] = None,
+    ) -> Iterator[tuple[str, str, str]]:
+        sql = (
+            "SELECT canonical_key, name, address FROM businesses "
+            "WHERE owner_name IS NULL"
+        )
+        params: list = []
+        if after_key:
+            sql += " AND canonical_key > ?"
+            params.append(after_key)
+        sql += " ORDER BY canonical_key"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        for row in self.conn.execute(sql, params):
+            yield (row["canonical_key"], row["name"], row["address"])
 
     def reset(self) -> None:
         for table in ("raw_fetches", "businesses", "sheet_row_map",

--- a/src/shmoney/sources/sdat_direct.py
+++ b/src/shmoney/sources/sdat_direct.py
@@ -1,0 +1,345 @@
+"""Maryland SDAT Business Express enrichment scraper.
+
+Enriches `businesses.owner_name` / `registered_at` for rows we already have.
+Not a SourceAdapter — it doesn't iterate remote pages. Operator points the
+CLI's `enrich` subcommand at this.
+
+Ban-avoidance is the primary design constraint. See docs/issue-27 or the plan
+file for the full rationale.
+"""
+from __future__ import annotations
+
+import hashlib
+import random
+import re
+import time
+import urllib.parse
+import urllib.robotparser
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+SEARCH_URL = "https://egov.maryland.gov/BusinessExpress/EntitySearch"
+ROBOTS_URL = "https://egov.maryland.gov/robots.txt"
+
+DEFAULT_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0 Safari/537.36 (+shmoney-scraper; contact: operator)"
+)
+
+_CHALLENGE_MARKERS = (
+    "cloudflare",
+    "captcha",
+    "access denied",
+    "attention required",
+    "just a moment",
+)
+
+_DEAD_STATUSES = {"forfeited", "dissolved", "merged", "revoked"}
+
+
+class SdatCircuitBreakerOpen(RuntimeError):
+    """Raised when the scraper must abort (429, challenge page, repeated 5xx,
+    robots disallow). The CLI catches this, saves watermark, exits 2."""
+
+
+@dataclass
+class SdatRecord:
+    legal_name: str
+    entity_type: str
+    status: str
+    department_id: str
+    formation_date: Optional[str]
+    principal_address: Optional[str]
+    resident_agent: Optional[str]
+    officers: list[str] = field(default_factory=list)
+
+
+def pick_owner(rec: SdatRecord) -> Optional[str]:
+    """Prefer first officer (corp). Fall back to resident agent (LLC).
+    None if neither."""
+    for name in rec.officers:
+        if name and name.strip():
+            return name.strip()
+    if rec.resident_agent and rec.resident_agent.strip():
+        return rec.resident_agent.strip()
+    return None
+
+
+def _cache_key(method: str, url: str, body: str) -> str:
+    h = hashlib.sha1()
+    h.update(method.encode())
+    h.update(b"|")
+    h.update(url.encode())
+    h.update(b"|")
+    h.update(body.encode())
+    return h.hexdigest()
+
+
+def _looks_like_challenge(text: str) -> bool:
+    lower = text.lower()
+    return any(m in lower for m in _CHALLENGE_MARKERS)
+
+
+def parse_search_results(html: str) -> list[dict]:
+    """Parse the EntitySearch results page. Returns a list of candidate
+    entities with fields used for match selection: dept_id, name, address,
+    status, detail_href."""
+    soup = BeautifulSoup(html, "html.parser")
+    out: list[dict] = []
+    # ASP.NET-style data-bound table. Rows live under a results table with
+    # class or id containing "Results". Tolerate both patterns.
+    table = soup.find("table", id=re.compile(r"[Rr]esults"))
+    if table is None:
+        table = soup.find("table", class_=re.compile(r"[Rr]esults"))
+    if table is None:
+        return []
+    for tr in table.find_all("tr"):
+        cells = tr.find_all(["td"])
+        if len(cells) < 3:
+            continue
+        link = tr.find("a")
+        out.append({
+            "dept_id": cells[0].get_text(strip=True),
+            "name": cells[1].get_text(strip=True) if len(cells) > 1 else "",
+            "status": cells[2].get_text(strip=True) if len(cells) > 2 else "",
+            "address": cells[3].get_text(strip=True) if len(cells) > 3 else "",
+            "detail_href": link.get("href") if link else None,
+        })
+    return out
+
+
+def parse_detail(html: str) -> Optional[SdatRecord]:
+    """Parse a single-entity detail page. Returns None if the page doesn't
+    look like an entity detail (e.g. blank stub)."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    def field_value(label_rx: str) -> Optional[str]:
+        label = soup.find(string=re.compile(label_rx, re.I))
+        if not label:
+            return None
+        # ASP.NET detail pages use label-then-value patterns — walk the
+        # next sibling cell/span.
+        parent = label.parent
+        sib = parent.find_next(["td", "span", "div"])
+        if sib is None:
+            return None
+        val = sib.get_text(" ", strip=True)
+        return val or None
+
+    legal_name = field_value(r"^\s*(Department|Entity)\s*Name")
+    dept_id = field_value(r"^\s*(Department|Business)\s*ID") or ""
+    entity_type = field_value(r"Entity\s*Type") or ""
+    status = field_value(r"Status") or ""
+    formation_date = field_value(r"(Formation|Incorporation)\s*Date")
+    principal = field_value(r"Principal\s*Office")
+    resident_agent = field_value(r"Resident\s*Agent\s*Name")
+
+    officers: list[str] = []
+    officer_section = soup.find(string=re.compile(r"Officers", re.I))
+    if officer_section:
+        table = officer_section.find_parent().find_next("table")
+        if table is not None:
+            for tr in table.find_all("tr"):
+                cells = tr.find_all("td")
+                if not cells:
+                    continue
+                # First cell name, tolerate title-column variants.
+                name = cells[0].get_text(" ", strip=True)
+                if name and name.lower() not in {"name", "officer"}:
+                    officers.append(name)
+
+    if not legal_name and not dept_id:
+        return None
+
+    return SdatRecord(
+        legal_name=legal_name or "",
+        entity_type=entity_type,
+        status=status,
+        department_id=dept_id,
+        formation_date=formation_date,
+        principal_address=principal,
+        resident_agent=resident_agent,
+        officers=officers,
+    )
+
+
+def _score_candidate(cand: dict, address_hint: Optional[str]) -> int:
+    score = 0
+    status_low = (cand.get("status") or "").lower()
+    if "active" in status_low:
+        score += 10
+    if any(d in status_low for d in _DEAD_STATUSES):
+        score -= 20
+    if address_hint:
+        addr_low = (cand.get("address") or "").lower()
+        # Zip prefix overlap + street-number overlap are cheap proxies for
+        # same-business vs namesake.
+        zip_match = re.search(r"\b\d{5}\b", addr_low)
+        hint_zip = re.search(r"\b\d{5}\b", address_hint.lower())
+        if zip_match and hint_zip and zip_match.group() == hint_zip.group():
+            score += 5
+        num_match = re.search(r"^\s*(\d+)", addr_low)
+        hint_num = re.search(r"^\s*(\d+)", address_hint.lower())
+        if num_match and hint_num and num_match.group(1) == hint_num.group(1):
+            score += 5
+    return score
+
+
+class SdatEnricher:
+    def __init__(
+        self,
+        client: Optional[httpx.Client] = None,
+        min_interval_s: float = 4.0,
+        jitter_s: float = 1.0,
+        user_agent: str = DEFAULT_UA,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        rng: Optional[random.Random] = None,
+        cache_dir: Optional[Path] = None,
+        check_robots: bool = True,
+    ):
+        self.min_interval_s = min_interval_s
+        self.jitter_s = jitter_s
+        self.user_agent = user_agent
+        self._now = now
+        self._sleep = sleep
+        self._rng = rng if rng is not None else random.Random()
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+        if self._cache_dir:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._last_fetch_at: Optional[float] = None
+        self._client = client if client is not None else httpx.Client(
+            timeout=30.0, headers={"User-Agent": user_agent}, follow_redirects=True
+        )
+        if check_robots:
+            self._assert_robots_allows()
+
+    def _assert_robots_allows(self) -> None:
+        try:
+            resp = self._client.get(ROBOTS_URL)
+        except httpx.HTTPError:
+            # No robots served — not a disallow.
+            return
+        if resp.status_code >= 400:
+            return
+        rp = urllib.robotparser.RobotFileParser()
+        rp.parse(resp.text.splitlines())
+        if not rp.can_fetch(self.user_agent, SEARCH_URL):
+            raise SdatCircuitBreakerOpen("robots.txt disallows EntitySearch")
+
+    def _throttle(self) -> None:
+        if self._last_fetch_at is None:
+            return
+        delay = self.min_interval_s + self._rng.uniform(-self.jitter_s, self.jitter_s)
+        delay = max(delay, 0.0)
+        wait = delay - (self._now() - self._last_fetch_at)
+        if wait > 0:
+            self._sleep(wait)
+
+    def _cache_read(self, key: str) -> Optional[str]:
+        if not self._cache_dir:
+            return None
+        p = self._cache_dir / f"{key}.html"
+        if p.exists():
+            return p.read_text(encoding="utf-8")
+        return None
+
+    def _cache_write(self, key: str, text: str) -> None:
+        if not self._cache_dir:
+            return
+        p = self._cache_dir / f"{key}.html"
+        p.write_text(text, encoding="utf-8")
+
+    def _fetch(self, method: str, url: str, data: Optional[dict] = None) -> str:
+        body = urllib.parse.urlencode(data or {}, doseq=True)
+        key = _cache_key(method, url, body)
+        cached = self._cache_read(key)
+        if cached is not None:
+            return cached
+
+        self._throttle()
+
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                if method == "GET":
+                    resp = self._client.get(url)
+                else:
+                    resp = self._client.post(url, data=data)
+            except httpx.HTTPError as e:
+                if attempts >= 2:
+                    raise SdatCircuitBreakerOpen(f"network error: {e}") from e
+                self._sleep(10.0)
+                continue
+            finally:
+                self._last_fetch_at = self._now()
+
+            status = resp.status_code
+            text = resp.text
+
+            if status == 429:
+                raise SdatCircuitBreakerOpen(
+                    f"429 received; retry-after={resp.headers.get('Retry-After')}"
+                )
+            if 500 <= status < 600:
+                if attempts >= 2:
+                    raise SdatCircuitBreakerOpen(f"{status} after retry")
+                self._sleep(10.0)
+                continue
+            if status >= 400:
+                raise SdatCircuitBreakerOpen(f"unexpected status {status}")
+            if _looks_like_challenge(text):
+                raise SdatCircuitBreakerOpen("challenge page detected")
+
+            self._cache_write(key, text)
+            return text
+
+    def enrich(
+        self, name: str, address_hint: Optional[str] = None
+    ) -> Optional[SdatRecord]:
+        search_html = self._fetch(
+            "POST", SEARCH_URL, data={"searchType": "Entity", "searchValue": name}
+        )
+        candidates = parse_search_results(search_html)
+        if not candidates:
+            return None
+
+        ranked = sorted(
+            candidates,
+            key=lambda c: _score_candidate(c, address_hint),
+            reverse=True,
+        )
+        best = ranked[0]
+        status_low = (best.get("status") or "").lower()
+        if any(d in status_low for d in _DEAD_STATUSES):
+            return None
+
+        href = best.get("detail_href")
+        if not href:
+            return None
+        detail_url = urllib.parse.urljoin(SEARCH_URL, href)
+        detail_html = self._fetch("GET", detail_url)
+        rec = parse_detail(detail_html)
+        if rec is None:
+            return None
+        status_low = (rec.status or "").lower()
+        if any(d in status_low for d in _DEAD_STATUSES):
+            return None
+        return rec
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def iter_enrichment_candidates(
+    rows: Iterable[tuple[str, str, str]],
+) -> Iterable[tuple[str, str, str]]:
+    """Pass-through iterator so the CLI can depend on an abstraction that
+    future adapters (property records, etc.) will share."""
+    yield from rows

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -57,6 +57,46 @@ def test_watermark_scoped_per_source(tmp_path):
     assert r.get_watermark("anne-arundel-license") == 300
 
 
+def test_text_watermark_roundtrip(tmp_path):
+    r = Repository(tmp_path / "t.db")
+    assert r.get_text_watermark("md-sdat-direct") is None
+    r.set_text_watermark("md-sdat-direct", "abc123")
+    assert r.get_text_watermark("md-sdat-direct") == "abc123"
+    r.set_text_watermark("md-sdat-direct", "def456")
+    assert r.get_text_watermark("md-sdat-direct") == "def456"
+
+
+def test_text_and_int_watermarks_coexist(tmp_path):
+    r = Repository(tmp_path / "t.db")
+    r.set_watermark("howard-license", 500)
+    r.set_text_watermark("md-sdat-direct", "key-xyz")
+    assert r.get_watermark("howard-license") == 500
+    assert r.get_text_watermark("md-sdat-direct") == "key-xyz"
+
+
+def test_iter_businesses_missing_owner(tmp_path):
+    r = Repository(tmp_path / "t.db")
+    r.upsert_business("k1", RawBusiness(source="a", name="A", address="1"))
+    r.upsert_business("k2", RawBusiness(source="a", name="B", address="2",
+                                        owner_name="Bob"))
+    r.upsert_business("k3", RawBusiness(source="a", name="C", address="3"))
+    rows = list(r.iter_businesses_missing_owner())
+    keys = [k for k, _, _ in rows]
+    assert keys == ["k1", "k3"]
+
+
+def test_iter_businesses_missing_owner_respects_limit_and_cursor(tmp_path):
+    r = Repository(tmp_path / "t.db")
+    for k in ("k1", "k2", "k3", "k4"):
+        r.upsert_business(k, RawBusiness(source="a", name=k, address="x"))
+    first = [k for k, _, _ in r.iter_businesses_missing_owner(limit=2)]
+    assert first == ["k1", "k2"]
+    second = [
+        k for k, _, _ in r.iter_businesses_missing_owner(limit=2, after_key="k2")
+    ]
+    assert second == ["k3", "k4"]
+
+
 def test_reset_wipes_all_tables(tmp_path):
     r = Repository(tmp_path / "t.db")
     raw = RawBusiness(source="yelp", name="Joe", address="1 Main")

--- a/tests/test_sdat_direct_adapter.py
+++ b/tests/test_sdat_direct_adapter.py
@@ -1,0 +1,298 @@
+"""Tests for the SDAT Business Express enrichment adapter.
+
+Fixtures are synthetic (not captured from the live portal). They exercise
+parsing contracts the operator can verify against real HTML before the
+first live run. Real-site HTML WILL differ — when that happens, capture
+fixtures into tests/fixtures/sdat/ and point these tests at them.
+"""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import httpx
+import pytest
+
+from shmoney.sources.sdat_direct import (
+    ROBOTS_URL,
+    SEARCH_URL,
+    SdatCircuitBreakerOpen,
+    SdatEnricher,
+    parse_detail,
+    parse_search_results,
+    pick_owner,
+)
+
+
+SEARCH_TWO_RESULTS = """
+<html><body>
+<table id="gvResults">
+  <tr><th>ID</th><th>Name</th><th>Status</th><th>Address</th></tr>
+  <tr>
+    <td>D12345678</td>
+    <td><a href="Details?id=D12345678">ACME CORPORATION</a></td>
+    <td>Active</td>
+    <td>100 Main St, Baltimore MD 21201</td>
+  </tr>
+  <tr>
+    <td>D87654321</td>
+    <td><a href="Details?id=D87654321">ACME CORPORATION</a></td>
+    <td>Forfeited</td>
+    <td>999 Other Rd, Annapolis MD 21401</td>
+  </tr>
+</table>
+</body></html>
+"""
+
+SEARCH_EMPTY = '<html><body><table id="gvResults"></table></body></html>'
+
+DETAIL_CORP = """
+<html><body>
+  <div>Department Name</div><div>ACME CORPORATION</div>
+  <div>Department ID</div><div>D12345678</div>
+  <div>Entity Type</div><div>Stock Corporation</div>
+  <div>Status</div><div>Active</div>
+  <div>Formation Date</div><div>2010-05-14</div>
+  <div>Principal Office</div><div>100 Main St, Baltimore MD 21201</div>
+  <div>Resident Agent Name</div><div>Jane Lawyer Esq.</div>
+  <h3>Officers</h3>
+  <table>
+    <tr><th>Name</th><th>Title</th></tr>
+    <tr><td>Alice Founder</td><td>President</td></tr>
+    <tr><td>Bob Cofounder</td><td>Secretary</td></tr>
+  </table>
+</body></html>
+"""
+
+DETAIL_LLC = """
+<html><body>
+  <div>Department Name</div><div>ACME HOLDINGS LLC</div>
+  <div>Department ID</div><div>W11112222</div>
+  <div>Entity Type</div><div>Domestic LLC</div>
+  <div>Status</div><div>Active</div>
+  <div>Formation Date</div><div>2018-11-02</div>
+  <div>Principal Office</div><div>5 Oak Ave, Columbia MD 21044</div>
+  <div>Resident Agent Name</div><div>Carol Owner</div>
+</body></html>
+"""
+
+DETAIL_FORFEITED = """
+<html><body>
+  <div>Department Name</div><div>DEAD CO</div>
+  <div>Department ID</div><div>D99999999</div>
+  <div>Status</div><div>Forfeited</div>
+  <div>Formation Date</div><div>1995-03-01</div>
+</body></html>
+"""
+
+CHALLENGE_PAGE = """
+<html><head><title>Just a moment...</title></head>
+<body>Cloudflare Attention Required: verify you are human.</body></html>
+"""
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        self.t += s
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+def _client(handler):
+    return httpx.Client(transport=_transport(handler), follow_redirects=True)
+
+
+def _robots_allow_handler(inner):
+    def handler(request):
+        if request.url.path.endswith("/robots.txt"):
+            return httpx.Response(200, text="User-agent: *\nAllow: /\n")
+        return inner(request)
+    return handler
+
+
+# --- parser-level tests ------------------------------------------------------
+
+
+def test_parse_search_results_extracts_rows():
+    rows = parse_search_results(SEARCH_TWO_RESULTS)
+    assert len(rows) == 2
+    assert rows[0]["dept_id"] == "D12345678"
+    assert rows[0]["status"] == "Active"
+    assert rows[0]["detail_href"].startswith("Details?id=D12345678")
+
+
+def test_parse_search_results_empty():
+    assert parse_search_results(SEARCH_EMPTY) == []
+
+
+def test_parse_detail_corp_extracts_officers():
+    rec = parse_detail(DETAIL_CORP)
+    assert rec is not None
+    assert rec.status == "Active"
+    assert rec.formation_date == "2010-05-14"
+    assert rec.officers[0] == "Alice Founder"
+    assert pick_owner(rec) == "Alice Founder"
+
+
+def test_parse_detail_llc_falls_back_to_resident_agent():
+    rec = parse_detail(DETAIL_LLC)
+    assert rec is not None
+    assert rec.officers == []
+    assert rec.resident_agent == "Carol Owner"
+    assert pick_owner(rec) == "Carol Owner"
+
+
+def test_parse_detail_forfeited_status_detected():
+    rec = parse_detail(DETAIL_FORFEITED)
+    assert rec is not None
+    assert "forfeited" in rec.status.lower()
+
+
+# --- enrich() end-to-end with MockTransport ---------------------------------
+
+
+def _enricher(handler, **kwargs):
+    client = _client(_robots_allow_handler(handler))
+    clock = FakeClock()
+    return SdatEnricher(
+        client=client,
+        min_interval_s=4.0,
+        jitter_s=0.0,
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=random.Random(0),
+        **kwargs,
+    ), clock
+
+
+def test_enrich_happy_path_corp(tmp_path):
+    calls: list[str] = []
+
+    def handler(request):
+        calls.append(request.url.path)
+        if request.url.path.endswith("EntitySearch"):
+            return httpx.Response(200, text=SEARCH_TWO_RESULTS)
+        return httpx.Response(200, text=DETAIL_CORP)
+
+    enricher, _ = _enricher(handler, cache_dir=tmp_path / "cache")
+    rec = enricher.enrich("ACME CORPORATION",
+                          address_hint="100 Main St, Baltimore MD 21201")
+    assert rec is not None
+    assert pick_owner(rec) == "Alice Founder"
+
+
+def test_enrich_zero_results_returns_none(tmp_path):
+    def handler(request):
+        return httpx.Response(200, text=SEARCH_EMPTY)
+    enricher, _ = _enricher(handler, cache_dir=tmp_path / "cache")
+    assert enricher.enrich("NOPE") is None
+
+
+def test_enrich_429_trips_circuit_breaker(tmp_path):
+    def handler(request):
+        if request.url.path.endswith("EntitySearch"):
+            return httpx.Response(429, headers={"Retry-After": "60"}, text="slow down")
+        return httpx.Response(200, text="")
+
+    enricher, _ = _enricher(handler, cache_dir=tmp_path / "cache")
+    with pytest.raises(SdatCircuitBreakerOpen):
+        enricher.enrich("ACME")
+
+
+def test_enrich_challenge_page_trips_breaker(tmp_path):
+    def handler(request):
+        return httpx.Response(200, text=CHALLENGE_PAGE)
+    enricher, _ = _enricher(handler, cache_dir=tmp_path / "cache")
+    with pytest.raises(SdatCircuitBreakerOpen):
+        enricher.enrich("ACME")
+
+
+def test_enrich_5xx_retries_once_then_gives_up(tmp_path):
+    hits = {"n": 0}
+
+    def handler(request):
+        hits["n"] += 1
+        return httpx.Response(503, text="down")
+
+    enricher, _ = _enricher(handler, cache_dir=tmp_path / "cache")
+    with pytest.raises(SdatCircuitBreakerOpen):
+        enricher.enrich("ACME")
+    assert hits["n"] == 2  # one attempt + one retry
+
+
+def test_rate_limit_sleeps_between_fetches(tmp_path):
+    def handler(request):
+        if request.url.path.endswith("EntitySearch"):
+            return httpx.Response(200, text=SEARCH_TWO_RESULTS)
+        return httpx.Response(200, text=DETAIL_CORP)
+
+    enricher, clock = _enricher(handler, cache_dir=tmp_path / "cache")
+    enricher.enrich("ACME", address_hint="100 Main St 21201")
+    # One throttle sleep between search POST and detail GET.
+    # jitter=0, min_interval=4 → one 4s sleep expected.
+    assert any(abs(s - 4.0) < 0.01 for s in clock.sleeps), clock.sleeps
+
+
+def test_cache_hits_skip_network(tmp_path):
+    hits = {"n": 0}
+
+    def handler(request):
+        hits["n"] += 1
+        if request.url.path.endswith("EntitySearch"):
+            return httpx.Response(200, text=SEARCH_TWO_RESULTS)
+        return httpx.Response(200, text=DETAIL_CORP)
+
+    cache = tmp_path / "cache"
+    enricher, _ = _enricher(handler, cache_dir=cache)
+    enricher.enrich("ACME", address_hint="100 Main St 21201")
+    first = hits["n"]
+    # Second call with same args — every fetch served from disk.
+    enricher2, _ = _enricher(handler, cache_dir=cache)
+    enricher2.enrich("ACME", address_hint="100 Main St 21201")
+    # Both fetches cached; second enricher makes no new business requests
+    # (robots.txt is intercepted by the allow-handler and not counted).
+    assert hits["n"] == first
+
+
+def test_robots_disallow_raises_on_init():
+    def handler(request):
+        if request.url.path.endswith("/robots.txt"):
+            return httpx.Response(
+                200, text="User-agent: *\nDisallow: /BusinessExpress/\n"
+            )
+        return httpx.Response(200, text="")
+    client = _client(handler)
+    with pytest.raises(SdatCircuitBreakerOpen):
+        SdatEnricher(client=client, check_robots=True)
+
+
+def test_dead_candidate_skipped_even_if_top_of_list(tmp_path):
+    # When the highest-scored match is Forfeited, the enricher skips it.
+    dead_first = """
+    <html><body><table id="gvResults">
+      <tr><th>ID</th><th>Name</th><th>Status</th><th>Address</th></tr>
+      <tr>
+        <td>D00000001</td>
+        <td><a href="Details?id=D00000001">ACME CORP</a></td>
+        <td>Forfeited</td>
+        <td>5 Oak Ave, Columbia MD 21044</td>
+      </tr>
+    </table></body></html>
+    """
+
+    def handler(request):
+        return httpx.Response(200, text=dead_first)
+
+    enricher, _ = _enricher(handler, cache_dir=tmp_path / "cache")
+    assert enricher.enrich("ACME CORP",
+                           address_hint="5 Oak Ave Columbia MD 21044") is None


### PR DESCRIPTION
## Summary
- New \`src/shmoney/sources/sdat_direct.py\`: \`SdatEnricher\` + parsers + \`SdatCircuitBreakerOpen\`.
- New CLI verb: \`pipeline enrich --source md-sdat-direct [--limit N] [--dry-run]\`. Iterates \`businesses WHERE owner_name IS NULL\` and fills owner_name / registered_at via the existing COALESCE upsert.
- Repository: \`iter_businesses_missing_owner\`, \`get_text_watermark\` / \`set_text_watermark\`, new \`cursor_text\` column on \`source_watermarks\` (idempotent migration).
- \`beautifulsoup4>=4.12\` added as a dependency.
- README: Enrichment section + ban-avoidance documentation.

## Ban-avoidance defaults (non-negotiable)
- 4.0s min interval between requests (± 1.0s jitter).
- Single-threaded, single httpx.Client / cookie jar per run.
- \`robots.txt\` consulted at init; disallow → abort.
- 429 → immediate \`SdatCircuitBreakerOpen\`, watermark saved.
- Challenge-page substring detection (\"cloudflare\", \"captcha\", \"attention required\", \"just a moment\", \"access denied\") → abort.
- 5xx tolerated once with a 10s backoff; second failure aborts.
- All responses cached to \`data/sdat_cache/<sha1>.html\` — reruns are zero-network.
- \`--limit\` hard-capped at 200.
- Realistic browser User-Agent with a contact suffix so an admin can reach out instead of blanket-blocking.

## Fixtures are synthetic
The HTML fixtures in \`tests/test_sdat_direct_adapter.py\` are synthetic — they match the field-label shape the parsers look for (e.g. \"Entity Type\", \"Formation Date\", \"Resident Agent Name\", \"Officers\"). Real portal HTML will differ. **Before the first live run**, capture one real search + detail page off-hours and confirm the parsers still locate the expected labels. If they don't, the parsers need tuning, not the tests.

## Closes
#27

## Human QA steps
- [x] \`pytest -q\` — 127 passed.
- [x] \`curl -s https://egov.maryland.gov/robots.txt\` — confirm \`BusinessExpress\` is not under any \`Disallow:\` rule before first live run.
- [x] \`pipeline enrich --dry-run --limit 5\` — prints 5 candidate rows, zero network traffic. Run \`sudo tcpdump -n host egov.maryland.gov\` alongside to verify silence.
- [ ] \`pipeline enrich --limit 3\` off-hours (20:00–06:00 ET). Observe per-request log lines ≥4s apart. At least one row with \"Inc.\" / \"Corp\" in the name should get \`owner_name\` filled.
- [ ] Re-run the same \`pipeline enrich --limit 3\` — every candidate served from \`data/sdat_cache/\`, no outbound requests. Verify with \`ls data/sdat_cache/\` (should contain SHA1-named \`.html\` files) and \`tcpdump\`.
- [ ] \`pipeline sheet-sync\` — Sheet's \`Owner Name\` column populated for the newly-enriched rows.
- [ ] Abort drill: temporarily edit \`sdat_direct.py\` to raise \`SdatCircuitBreakerOpen\` on first request; run \`pipeline enrich --limit 3\`; confirm CLI exits with code 2 and watermark is saved (\`sqlite3 data/pipeline.db 'SELECT cursor_text FROM source_watermarks WHERE source=\"md-sdat-direct\"'\`).
- [ ] Edge case: operator typos \`--limit 10000\` — clamped silently to 200, no 10k-row sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)