### PR TITLE
docs: post-v1 state snapshot for next session handoff

### DIFF
--- a/docs/state-2026-04-20.md
+++ b/docs/state-2026-04-20.md
@@ -1,0 +1,128 @@
+# Pipeline state snapshot — 2026-04-20
+
+Reference doc for the next operator / Claude Code session. Not a roadmap —
+a frozen status report. Dates here are absolute.
+
+## Where v1 ended
+
+Issue #1 (PRD) closed. Shipped features:
+
+- 5 working adapters: `yelp`, `md-sdat` (OpenCorporates), `baltimore-city`
+  (MBE/WBE), `howard`, `anne-arundel`.
+- 3 deferred jurisdictions (`baltimore-county`, `harford`, `carroll`) with
+  loud `BadParameter` errors pointing at `docs/license-sources.md`.
+- Canonical-key join via COALESCE upsert (`src/shmoney/repo.py`).
+- Address normalization (street suffix + zip hyphen) in `canonicalize.py`.
+- Website classifier + 1–5 scoring + audit cache (30-day freshness).
+- Sheet write throttle (1.1s between writes, under 60/min Google quota).
+- Watermark resume on license adapters.
+- Ops subcommands: `init`, `run`, `sheet-sync`, `reset`, `enrich` (CLI stub
+  only — see #27/#28 note below).
+- README with setup, credentials, per-source usage, troubleshooting.
+
+127 tests passing on `dev` as of this commit.
+
+## Live data state
+
+After a ~30-min Baltimore City sweep (2026-04-20 AM ET, crashed at
+t=29m59s due to WSL DNS hiccup, not a pipeline bug):
+
+- `data/pipeline.db` holds **605 rows** with both `owner_name` and `phone`
+  populated — i.e. 605 high-quality MBE/WBE certified businesses ready
+  for outreach.
+- Sheet was manually wiped to headers only before the run; Sheet row count
+  depends on how many of the 605 were written before the crash (check via
+  `SELECT COUNT(*) FROM sheet_row_map`). `pipeline sheet-sync` reconciles.
+- Baltimore City watermark not cleared (run aborted), so
+  `pipeline run --source baltimore-city --limit 2000` resumes from the
+  last completed page without duplicates.
+
+## Owner + phone coverage matrix (why only MBE is "high quality")
+
+| Adapter | Owner | Phone |
+| --- | --- | --- |
+| `baltimore-city` (MBE/WBE) | ✅ | ✅ |
+| `yelp` | ❌ | ✅ |
+| `howard` | ❌ | ❌ |
+| `anne-arundel` | ❌ | ❌ |
+| `md-sdat` (OpenCorporates) | n/a — no API token |
+| `md-sdat-direct` (SDAT portal) | blocked by Cloudflare + Captcha |
+
+For the strict "owner AND phone" metric, Baltimore City is the only source
+that contributes. Running other sources only enriches existing MBE rows
+(via canonical_key join) and burns Sheet-write throttle.
+
+## Open issues (priority order)
+
+### #29 — County liquor-license licensee-name backfill (highest leverage)
+
+Howard's Socrata feed already exposes `corp_name` (legal entity). PR #21
+stripped it from `owner_name` to avoid confusing entity with human owner.
+Resurface it as a new `entity_name` field on `RawBusiness` + a "Legal
+Entity" column. Also investigate whether Anne Arundel has a parallel
+feed with licensee names (ArcGIS layer 9 doesn't).
+
+Low effort. Biggest unlock: later enrichment adapters can search by
+entity name instead of DBA → higher hit rate.
+
+### #30 — SDAT Real Property as owner-name signal (gated)
+
+Different system from Business Express — not CF-gated historically, but
+operator must confirm with `curl -sS https://sdat.dat.maryland.gov/RealProperty/Pages/default.aspx | grep -Ei 'cloudflare|captcha'`
+before writing code. If clean, resurrects the infrastructure from closed
+PR #28 (throttle, cache, circuit breaker) and searches by address, not
+entity name. Includes a landlord-vs-owner classifier.
+
+### #27 — MD SDAT Business Express enrichment adapter (blocked)
+
+Closed PR #28 attempted this. Live portal is behind Cloudflare + Captcha;
+circuit breaker correctly refused to proceed. Issue stays open as a
+placeholder in case the blocker lifts or a sanctioned access path opens.
+Do **not** re-attempt with headless browsers + proxy solvers — explicitly
+out of scope.
+
+### #6 — Facebook Pages adapter
+
+Open, unstarted. Separate PR branch `feat/issue-6-facebook-adapter` with
+a partial implementation. Strategic note: Facebook Pages is CF-protected
+and bot-sniffed; expect similar abort-on-challenge behavior to SDAT
+direct.
+
+### #4 — Maryland SDAT adapter (superseded in practice)
+
+Originally the blocker for #7. Implemented as OpenCorporates (PR #12).
+Kept open because the operator doesn't have a live `OPENCORPORATES_API_TOKEN`,
+so the adapter ships but is inert. Issue is really about funding an API
+token, not shipping code.
+
+## Closed recently (for context)
+
+| # | Title | Result |
+| --- | --- | --- |
+| 1 | v1 PRD | closed; v1 complete |
+| 7 | Six city/county adapters | closed after Phase D (PR #22) |
+| 8 | Ops polish (watermark, dry-run, reset, ...) | closed (PR #23) |
+| 9 | Full metro sweep + README | partial: README shipped (PR #24), sweep is operator HITL |
+| 25 | Sheet-write throttle | closed (PR #26) |
+| 28 | (PR) SDAT direct adapter | closed unmerged — Cloudflare-blocked |
+
+## Recommended next moves
+
+1. **Resume the sweep** if you want more MBE rows past 605.
+   ```bash
+   pipeline sheet-sync          # reconcile Sheet with DB first
+   pipeline run --source baltimore-city --limit 2000
+   ```
+2. **Ship #29** — cheapest unlock, pure adapter work.
+3. **Gate-check #30** with the `curl` test before writing code.
+4. **Manual outreach loop**: export the 605 DB rows to a working CSV,
+   start calling. No code needed; pipeline's job is done.
+
+## Files the next session should read first
+
+- `CLAUDE.md` — project conventions (if present).
+- `README.md` — current CLI surface.
+- `docs/license-sources.md` — per-jurisdiction feed status.
+- `src/shmoney/orchestrator.py` — the `run_once` + `sheet_sync` control
+  flow. If you understand this file, everything else is obvious.
+- `src/shmoney/cli.py` — all CLI wiring, including the 1.1s Sheet throttle.


### PR DESCRIPTION
## Summary
Single new file: \`docs/state-2026-04-20.md\`. Frozen snapshot of where v1 ended, live data state (605 high-quality rows in \`data/pipeline.db\`, Baltimore City sweep crashed at t=29m59s due to a WSL DNS hiccup), open-issue priorities (#29, #30, #27, #6, #4), and recommended next moves.

Intended as the first file the next Claude Code instance reads to orient.

## Closes
— (docs-only handoff, no issue)

## Human QA steps
- [ ] Render \`docs/state-2026-04-20.md\` on GitHub — tables format correctly, no broken internal links.
- [ ] Issue IDs referenced (#29, #30, #27, #6, #4) all resolve to open issues.
- [ ] \`docs/license-sources.md\` still exists and matches what the snapshot claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)