### PR TITLE
feat: sheet-sync orders no-website rows first, then by score ASC

### DIFF
--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -60,6 +60,12 @@ class _GspreadWorksheetAdapter:
             self._throttle()
             self._ws.update_cells(cells, value_input_option="RAW")
 
+    def clear_data_rows(self):
+        self._throttle()
+        # batch_clear leaves the row frame intact; resetting values avoids
+        # a separate resize + shape mismatch.
+        self._ws.batch_clear(["A2:ZZ"])
+
 
 @app.command()
 def init() -> None:

--- a/src/shmoney/orchestrator.py
+++ b/src/shmoney/orchestrator.py
@@ -73,8 +73,14 @@ def build_business_row(
 
 
 def sheet_sync(repo: Repository, sheets: SheetsWriter) -> int:
+    """Rebuild the Sheet from SQLite in priority order.
+
+    Priority: rows with no website first (highest outreach value — target
+    doesn't exist online yet), then by `Online Presence` score ascending
+    (weakest real sites next, strongest last).
+    """
     sheets.ensure_schema()
-    count = 0
+    scored: list[tuple[bool, int, str, dict, object, int, Optional[str]]] = []
     for key in repo.list_sheet_keys():
         merged = repo.get_business(key)
         if not merged:
@@ -82,6 +88,15 @@ def sheet_sync(repo: Repository, sheets: SheetsWriter) -> int:
         classification = classify(merged.get("website"))
         audit_report = repo.get_audit(key)
         s, tag = score(classification, audit_report)
+        has_website = bool((merged.get("website") or "").strip())
+        scored.append((has_website, s, key, merged, classification, s, tag))
+
+    # False (no website) sorts before True; then score ascending.
+    scored.sort(key=lambda t: (t[0], t[1]))
+
+    sheets.reset_data_rows()
+    count = 0
+    for _, _, key, merged, classification, s, tag in scored:
         row_dict = build_business_row(merged, classification, s, tag)
         row_idx = sheets.upsert(key, row_dict)
         repo.record_sheet_row(key, row_idx)

--- a/src/shmoney/sheets.py
+++ b/src/shmoney/sheets.py
@@ -37,6 +37,7 @@ class WorksheetClient(Protocol):
     def get_all_values(self) -> list[list[str]]: ...
     def append_row(self, values: list[str]) -> None: ...
     def batch_update_cells(self, updates: list[tuple[int, int, str]]) -> None: ...
+    def clear_data_rows(self) -> None: ...
 
 
 class SheetsWriter:
@@ -72,6 +73,15 @@ class SheetsWriter:
                 self._key_to_row[row[key_col]] = idx
         self._row_count = len(values)
         self._loaded = True
+
+    def reset_data_rows(self) -> None:
+        """Wipe all Sheet data rows (row 2 onward) and reset internal state.
+        Header row is preserved."""
+        if not self._loaded:
+            self.ensure_schema()
+        self.ws.clear_data_rows()
+        self._key_to_row = {}
+        self._row_count = 1
 
     def upsert(self, canonical_key: str, business: dict[str, str]) -> int:
         if not self._loaded:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,10 @@ class FakeWorksheet:
                 row.append("")
             row[c - 1] = v
 
+    def clear_data_rows(self) -> None:
+        if self.rows:
+            self.rows = self.rows[:1]
+
 
 @pytest.fixture
 def fake_ws():

--- a/tests/test_smoke_pipeline.py
+++ b/tests/test_smoke_pipeline.py
@@ -282,6 +282,61 @@ def test_sheet_sync_rebuilds_rows_from_sqlite(tmp_path, fake_ws):
     assert names == {"Biz A", "Biz B"}
 
 
+def test_sheet_sync_orders_no_website_rows_first(tmp_path, fake_ws):
+    from shmoney.orchestrator import sheet_sync
+    rows = [
+        RawBusiness(source="yelp", name="Has Weak Site", address="1 Main",
+                    website="https://weaksite.example"),
+        RawBusiness(source="yelp", name="No Site", address="2 Main",
+                    website=None),
+        RawBusiness(source="yelp", name="Social Only", address="3 Main",
+                    website="https://facebook.com/x"),
+    ]
+    repo = Repository(tmp_path / "t.db")
+    writer = SheetsWriter(fake_ws)
+    run_once(StubAdapter(rows), repo, writer)
+    # Wipe the sheet and resync in priority order.
+    writer2 = SheetsWriter(fake_ws)
+    sheet_sync(repo, writer2)
+    # Row 1 is header. Data rows 2..N in priority order:
+    # no-website rows first, then social-only, then weak site.
+    data_names = [fake_ws.rows[i][_col("Business Name")]
+                  for i in range(1, len(fake_ws.rows))]
+    assert data_names[0] == "No Site"
+    # "No Site" must precede anything with a website.
+    no_site_idx = data_names.index("No Site")
+    weak_site_idx = data_names.index("Has Weak Site")
+    social_idx = data_names.index("Social Only")
+    assert no_site_idx < weak_site_idx
+    assert no_site_idx < social_idx
+
+
+def test_sheet_sync_secondary_sort_by_score_ascending(tmp_path, fake_ws):
+    # Two no-website rows: they should sort by score ASC (weakest first).
+    # Score 1 = no site (lowest). Both get 1, so tie-break by name ordering
+    # we at least expect both to cluster before any website row.
+    from shmoney.orchestrator import sheet_sync
+    rows = [
+        RawBusiness(source="yelp", name="Weak Real",
+                    address="1 Main",
+                    website="https://real.example"),
+        RawBusiness(source="yelp", name="NoSite A",
+                    address="2 Main", website=None),
+        RawBusiness(source="yelp", name="NoSite B",
+                    address="3 Main", website=None),
+    ]
+    repo = Repository(tmp_path / "t.db")
+    writer = SheetsWriter(fake_ws)
+    run_once(StubAdapter(rows), repo, writer)
+    writer2 = SheetsWriter(fake_ws)
+    sheet_sync(repo, writer2)
+    data_names = [fake_ws.rows[i][_col("Business Name")]
+                  for i in range(1, len(fake_ws.rows))]
+    # Both no-website rows precede the real site.
+    assert data_names.index("NoSite A") < data_names.index("Weak Real")
+    assert data_names.index("NoSite B") < data_names.index("Weak Real")
+
+
 def test_sheet_sync_is_idempotent(tmp_path, fake_ws):
     from shmoney.orchestrator import sheet_sync
 


### PR DESCRIPTION
## Summary
- \`sheet_sync\` now scores every row, clears the Sheet's data rows, and re-writes in priority order: \`website IS NULL\` first, then by Online Presence score ascending.
- New \`SheetsWriter.reset_data_rows()\` + \`WorksheetClient.clear_data_rows\` protocol method; implemented on the gspread adapter (throttled \`batch_clear([\"A2:ZZ\"])\`) and the test FakeWorksheet.
- Two regression tests in \`tests/test_smoke_pipeline.py\`:
  - no-website row precedes weak-real-site and social-only rows,
  - two no-website rows both precede a row with a real website.

## Closes
#32

## Human QA steps
- [ ] \`pytest -q\` — 111 passed.
- [ ] On a Sheet with mixed rows (some \`Website URL\` empty, some populated), run \`pipeline sheet-sync\`. All rows with empty Website URL cluster at the top.
- [ ] Second run of \`pipeline sheet-sync\` produces the same ordering — deterministic, no drift.
- [ ] Edge case: Sheet with only one row (all have websites) — still completes cleanly, no crash.
- [ ] Cost note: sheet-sync now wipes + re-appends every row. For 605 rows at 1.1s throttle that's ~11 min. Operators should run sheet-sync sparingly, not after every ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)