### PR TITLE
feat: website discovery via DuckDuckGo with strict match

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,33 @@ the last checkpointed offset. Successful runs clear the watermark.
 ## Subcommands
 
 ```bash
-pipeline sheet-sync      # rebuild Sheet rows from SQLite (e.g. after an accidental delete)
-pipeline reset           # wipe SQLite only (not the Sheet). --yes skips the prompt.
+pipeline sheet-sync              # rebuild Sheet rows from SQLite in priority order
+pipeline reset                   # wipe SQLite only (not the Sheet). --yes skips the prompt.
+pipeline discover-websites       # fill missing websites via DuckDuckGo (strict match)
+```
+
+### `discover-websites`
+
+For every row in `businesses` where `website IS NULL`, run a DuckDuckGo
+search, fuzzy-match the top 5 results against the business name, verify
+the candidate's homepage mentions the business city / zip / phone, and
+backfill `website` only when all gates pass.
+
+Purpose: the adapter feeds (MBE `user_website`, Yelp's URL field) miss
+many real websites. Without discovery, the priority-ordered Sheet surfaces
+"no-website" rows that actually have sites, diluting the high-value leads.
+
+Ban-avoidance defaults:
+- 3.0s min interval ± 1.0s jitter.
+- DuckDuckGo `robots.txt` consulted at init.
+- 429 / challenge → circuit-breaker abort.
+- All search + homepage responses cached under `data/discovery_cache/`.
+- `--limit` hard-capped at 500.
+
+```bash
+pipeline discover-websites --dry-run          # prints candidate list, zero network
+pipeline discover-websites --limit 50         # conservative first pass
+pipeline sheet-sync                           # re-apply priority ordering
 ```
 
 ## Diagnostics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Baltimore small business lead pipeline"
 requires-python = ">=3.11"
 dependencies = [
+    "beautifulsoup4>=4.12",
     "httpx>=0.27",
     "typer>=0.12",
     "gspread>=6.0",

--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -185,5 +185,79 @@ def reset(
     typer.echo("pipeline reset ok")
 
 
+_DISCOVER_HARD_MAX = 500
+
+
+@app.command("discover-websites")
+def discover_websites_cmd(
+    limit: int = typer.Option(25, "--limit"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+) -> None:
+    limit = min(max(limit, 0), _DISCOVER_HARD_MAX)
+    cfg = load_config()
+    repo = Repository(cfg.db_path)
+    try:
+        candidates = list(repo.iter_businesses_missing_website(limit=limit))
+        typer.echo(
+            f"[website-discovery] candidates={len(candidates)} limit={limit} "
+            f"dry_run={dry_run}"
+        )
+        if dry_run:
+            for key, name, addr, phone in candidates:
+                typer.echo(f"  DRY {key} name={name!r}")
+            return
+        if not candidates:
+            return
+
+        from .discover import (
+            WebsiteDiscoverer,
+            WebsiteDiscoveryCircuitBreakerOpen,
+        )
+        from .sources.base import RawBusiness
+        from dataclasses import asdict
+
+        discoverer = WebsiteDiscoverer(
+            cache_dir=cfg.db_path.parent / "discovery_cache"
+        )
+        queried = matched = aborted_on = 0
+        aborted: str | None = None
+        try:
+            for key, name, addr, phone in candidates:
+                queried += 1
+                try:
+                    result = discoverer.discover(name, addr, phone)
+                except WebsiteDiscoveryCircuitBreakerOpen as e:
+                    aborted = str(e)
+                    typer.echo(f"  ABORT {key}: {aborted}")
+                    break
+                if result is None:
+                    typer.echo(f"  NO-MATCH {key} name={name!r}")
+                    continue
+                matched += 1
+                raw = RawBusiness(
+                    source="website-discovery",
+                    name=name,
+                    address=addr,
+                    website=result.url,
+                )
+                repo.record_raw("website-discovery", key, asdict(raw))
+                repo.upsert_business(key, raw)
+                typer.echo(
+                    f"  OK {key} url={result.url} "
+                    f"conf={result.confidence:.2f} reasons={result.reasons}"
+                )
+        finally:
+            discoverer.close()
+
+        typer.echo(
+            f"[website-discovery] queried={queried} matched={matched} "
+            f"aborted_on={aborted!r}"
+        )
+        if aborted:
+            raise typer.Exit(code=2)
+    finally:
+        repo.close()
+
+
 def main() -> None:
     app()

--- a/src/shmoney/discover.py
+++ b/src/shmoney/discover.py
@@ -1,0 +1,335 @@
+"""DuckDuckGo-backed website discovery for rows where adapter feeds didn't
+supply a URL. Strict match: non-social domain + name-token overlap +
+homepage mentions city/zip/phone.
+
+Ban-safety mirrors the closed PR #28 SdatEnricher pattern: throttle +
+jitter + cache + circuit breaker + challenge detection.
+"""
+from __future__ import annotations
+
+import hashlib
+import random
+import re
+import time
+import urllib.parse
+import urllib.robotparser
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+DDG_URL = "https://html.duckduckgo.com/html/"
+
+DEFAULT_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0 Safari/537.36 (+shmoney-scraper; contact: operator)"
+)
+
+_SOCIAL_AND_DIRECTORY_BLOCKLIST = frozenset(
+    {
+        "facebook.com", "m.facebook.com", "fb.com", "fb.me",
+        "instagram.com", "m.instagram.com",
+        "twitter.com", "x.com",
+        "linkedin.com",
+        "yelp.com", "m.yelp.com",
+        "bbb.org",
+        "manta.com", "dnb.com",
+        "yellowpages.com", "superpages.com",
+        "mapquest.com",
+        "chamberofcommerce.com",
+        "tripadvisor.com",
+        "glassdoor.com", "indeed.com",
+        "crunchbase.com",
+        "youtube.com", "pinterest.com",
+        "duckduckgo.com", "google.com",
+    }
+)
+
+_NAME_STOPWORDS = frozenset(
+    {
+        "llc", "inc", "incorporated", "corp", "corporation", "co", "company",
+        "the", "and", "&", "of", "a", "an",
+    }
+)
+
+_CHALLENGE_MARKERS = (
+    "captcha",
+    "are you a robot",
+    "verify you're human",
+    "access denied",
+    "cloudflare",
+    "attention required",
+    "just a moment",
+)
+
+
+class WebsiteDiscoveryCircuitBreakerOpen(RuntimeError):
+    """Abort signal — 429 / challenge / repeated 5xx / robots disallow."""
+
+
+@dataclass
+class DiscoveryResult:
+    url: str
+    confidence: float
+    reasons: list[str] = field(default_factory=list)
+
+
+def _tokenize_name(name: str) -> set[str]:
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9\s]", " ", s)
+    tokens = {t for t in s.split() if len(t) >= 2 and t not in _NAME_STOPWORDS}
+    return tokens
+
+
+def _name_overlap(name: str, candidate_text: str) -> float:
+    tokens = _tokenize_name(name)
+    if not tokens:
+        return 0.0
+    cand = candidate_text.lower()
+    hits = sum(1 for t in tokens if t in cand)
+    return hits / len(tokens)
+
+
+def _extract_city(address: str) -> Optional[str]:
+    # Expect "<street>, <city>, <state> <zip>" — pick the city segment.
+    parts = [p.strip() for p in address.split(",")]
+    if len(parts) >= 2:
+        return parts[-2] or None
+    return None
+
+
+def _extract_zip(address: str) -> Optional[str]:
+    m = re.search(r"\b(\d{5})(?:-\d{4})?\b", address)
+    return m.group(1) if m else None
+
+
+def _normalize_phone(phone: Optional[str]) -> Optional[str]:
+    if not phone:
+        return None
+    digits = re.sub(r"\D", "", phone)
+    return digits[-10:] if len(digits) >= 10 else None
+
+
+def _looks_like_challenge(text: str) -> bool:
+    lower = text.lower()
+    return any(m in lower for m in _CHALLENGE_MARKERS)
+
+
+def _cache_key(method: str, url: str, body: str) -> str:
+    h = hashlib.sha1()
+    h.update(method.encode())
+    h.update(b"|")
+    h.update(url.encode())
+    h.update(b"|")
+    h.update(body.encode())
+    return h.hexdigest()
+
+
+def _host_of(url: str) -> str:
+    host = urllib.parse.urlparse(url).netloc.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def parse_ddg_results(html: str) -> list[dict]:
+    """DDG's /html/ endpoint returns a table of `<a class="result__a">` title
+    links with adjacent `<a class="result__snippet">` snippets. Host
+    exposed via the redirect URL's `uddg` query param."""
+    soup = BeautifulSoup(html, "html.parser")
+    results: list[dict] = []
+    for block in soup.select(".result"):
+        a = block.select_one("a.result__a")
+        if not a:
+            continue
+        href = a.get("href") or ""
+        title = a.get_text(" ", strip=True)
+        snippet_el = block.select_one(".result__snippet")
+        snippet = snippet_el.get_text(" ", strip=True) if snippet_el else ""
+        # DDG wraps outbound links in /l/?uddg=<encoded-url>.
+        parsed = urllib.parse.urlparse(href)
+        qs = urllib.parse.parse_qs(parsed.query)
+        uddg = qs.get("uddg") or []
+        url = uddg[0] if uddg else href
+        results.append({"title": title, "snippet": snippet, "url": url})
+        if len(results) >= 5:
+            break
+    return results
+
+
+class WebsiteDiscoverer:
+    def __init__(
+        self,
+        client: Optional[httpx.Client] = None,
+        min_interval_s: float = 3.0,
+        jitter_s: float = 1.0,
+        user_agent: str = DEFAULT_UA,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        rng: Optional[random.Random] = None,
+        cache_dir: Optional[Path] = None,
+        check_robots: bool = True,
+    ):
+        self.min_interval_s = min_interval_s
+        self.jitter_s = jitter_s
+        self.user_agent = user_agent
+        self._now = now
+        self._sleep = sleep
+        self._rng = rng if rng is not None else random.Random()
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+        if self._cache_dir:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._last_fetch_at: Optional[float] = None
+        self._client = client if client is not None else httpx.Client(
+            timeout=30.0, headers={"User-Agent": user_agent}, follow_redirects=True
+        )
+        if check_robots:
+            self._assert_robots_allows(DDG_URL)
+
+    def _assert_robots_allows(self, url: str) -> None:
+        parsed = urllib.parse.urlparse(url)
+        robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+        try:
+            resp = self._client.get(robots_url)
+        except httpx.HTTPError:
+            return
+        if resp.status_code >= 400:
+            return
+        rp = urllib.robotparser.RobotFileParser()
+        rp.parse(resp.text.splitlines())
+        if not rp.can_fetch(self.user_agent, url):
+            raise WebsiteDiscoveryCircuitBreakerOpen(
+                f"robots.txt disallows {url}"
+            )
+
+    def _throttle(self) -> None:
+        if self._last_fetch_at is None:
+            return
+        delay = self.min_interval_s + self._rng.uniform(-self.jitter_s, self.jitter_s)
+        delay = max(delay, 0.0)
+        wait = delay - (self._now() - self._last_fetch_at)
+        if wait > 0:
+            self._sleep(wait)
+
+    def _cache_read(self, key: str) -> Optional[str]:
+        if not self._cache_dir:
+            return None
+        p = self._cache_dir / f"{key}.html"
+        return p.read_text(encoding="utf-8") if p.exists() else None
+
+    def _cache_write(self, key: str, text: str) -> None:
+        if not self._cache_dir:
+            return
+        p = self._cache_dir / f"{key}.html"
+        p.write_text(text, encoding="utf-8")
+
+    def _fetch(self, method: str, url: str, params: Optional[dict] = None) -> str:
+        body = urllib.parse.urlencode(params or {}, doseq=True)
+        key = _cache_key(method, url, body)
+        cached = self._cache_read(key)
+        if cached is not None:
+            return cached
+
+        self._throttle()
+
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                resp = self._client.get(url, params=params) if method == "GET" \
+                    else self._client.post(url, data=params)
+            except httpx.HTTPError as e:
+                if attempts >= 2:
+                    raise WebsiteDiscoveryCircuitBreakerOpen(f"network error: {e}") from e
+                self._sleep(10.0)
+                continue
+            finally:
+                self._last_fetch_at = self._now()
+
+            status = resp.status_code
+            text = resp.text
+
+            if status == 429:
+                raise WebsiteDiscoveryCircuitBreakerOpen(
+                    f"429; retry-after={resp.headers.get('Retry-After')}"
+                )
+            if 500 <= status < 600:
+                if attempts >= 2:
+                    raise WebsiteDiscoveryCircuitBreakerOpen(f"{status} after retry")
+                self._sleep(10.0)
+                continue
+            if status >= 400:
+                raise WebsiteDiscoveryCircuitBreakerOpen(f"unexpected status {status}")
+            if _looks_like_challenge(text):
+                raise WebsiteDiscoveryCircuitBreakerOpen("challenge page detected")
+
+            self._cache_write(key, text)
+            return text
+
+    def discover(
+        self,
+        name: str,
+        address: str,
+        phone: Optional[str] = None,
+    ) -> Optional[DiscoveryResult]:
+        city = _extract_city(address)
+        zipc = _extract_zip(address)
+        phone_digits = _normalize_phone(phone)
+
+        query = f'"{name}"'
+        if city:
+            query += f" {city}"
+        elif zipc:
+            query += f" {zipc}"
+
+        search_html = self._fetch("GET", DDG_URL, params={"q": query})
+        candidates = parse_ddg_results(search_html)
+
+        best: Optional[DiscoveryResult] = None
+        for c in candidates:
+            host = _host_of(c["url"])
+            if not host:
+                continue
+            if host in _SOCIAL_AND_DIRECTORY_BLOCKLIST:
+                continue
+            overlap = _name_overlap(name, c["title"] + " " + c["snippet"])
+            if overlap < 0.7:
+                continue
+
+            reasons = [f"name_overlap={overlap:.2f}", f"host={host}"]
+
+            # Homepage verification.
+            try:
+                homepage = self._fetch("GET", c["url"])
+            except WebsiteDiscoveryCircuitBreakerOpen:
+                raise
+            except Exception:
+                continue
+            homepage_lower = homepage.lower()
+            city_hit = bool(city and city.lower() in homepage_lower)
+            zip_hit = bool(zipc and zipc in homepage_lower)
+            phone_hit = False
+            if phone_digits:
+                homepage_digits = re.sub(r"\D", "", homepage_lower)
+                phone_hit = phone_digits in homepage_digits
+            if not (city_hit or zip_hit or phone_hit):
+                continue
+            if city_hit:
+                reasons.append("city_match")
+            if zip_hit:
+                reasons.append("zip_match")
+            if phone_hit:
+                reasons.append("phone_match")
+
+            candidate = DiscoveryResult(
+                url=c["url"], confidence=overlap, reasons=reasons
+            )
+            if best is None or candidate.confidence > best.confidence:
+                best = candidate
+        return best
+
+    def close(self) -> None:
+        self._client.close()

--- a/src/shmoney/repo.py
+++ b/src/shmoney/repo.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from .audit import AuditFlags, AuditReport
 from .sources.base import RawBusiness
@@ -233,6 +233,26 @@ class Repository:
 
     def clear_watermark(self, source: str) -> None:
         self.conn.execute("DELETE FROM source_watermarks WHERE source = ?", (source,))
+
+    def iter_businesses_missing_website(
+        self,
+        limit: Optional[int] = None,
+        after_key: Optional[str] = None,
+    ) -> Iterator[tuple[str, str, str, Optional[str]]]:
+        sql = (
+            "SELECT canonical_key, name, address, phone FROM businesses "
+            "WHERE website IS NULL OR website = ''"
+        )
+        params: list = []
+        if after_key:
+            sql += " AND canonical_key > ?"
+            params.append(after_key)
+        sql += " ORDER BY canonical_key"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        for row in self.conn.execute(sql, params):
+            yield (row["canonical_key"], row["name"], row["address"], row["phone"])
 
     def reset(self) -> None:
         for table in ("raw_fetches", "businesses", "sheet_row_map",

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,282 @@
+"""Tests for the DuckDuckGo-backed website discovery module."""
+from __future__ import annotations
+
+import random
+
+import httpx
+import pytest
+
+from shmoney.discover import (
+    WebsiteDiscoverer,
+    WebsiteDiscoveryCircuitBreakerOpen,
+    _host_of,
+    _name_overlap,
+    _tokenize_name,
+    parse_ddg_results,
+)
+
+
+DDG_TWO_HITS_TEMPLATE = """
+<html><body>
+<div class="result">
+  <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//paniaguaenterprises.com/">Paniagua Enterprises Baltimore | Construction</a>
+  <a class="result__snippet">Paniagua Enterprises Inc — general contracting in Baltimore, MD.</a>
+</div>
+<div class="result">
+  <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//www.yelp.com/biz/paniagua-enterprises">Paniagua Enterprises | Yelp</a>
+  <a class="result__snippet">Reviews of Paniagua Enterprises in Baltimore.</a>
+</div>
+</body></html>
+"""
+
+DDG_NAMESAKE_TEMPLATE = """
+<html><body>
+<div class="result">
+  <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//namesake-tx.example/">Paniagua Enterprises — Austin TX</a>
+  <a class="result__snippet">Paniagua Enterprises serving the greater Austin area.</a>
+</div>
+</body></html>
+"""
+
+HOMEPAGE_HAS_BALTIMORE = """
+<html><head><title>Paniagua</title></head>
+<body>
+<p>We serve Baltimore and surrounding areas.</p>
+<p>Call us at 410-555-0000.</p>
+</body></html>
+"""
+
+HOMEPAGE_NO_CITY = "<html><body><p>Welcome to our Texas contracting firm.</p></body></html>"
+
+CHALLENGE_HTML = "<html><body>Please verify you're human (cloudflare captcha).</body></html>"
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+def _client(handler):
+    return httpx.Client(transport=_transport(handler), follow_redirects=True)
+
+
+def _robots_allow_handler(inner):
+    def handler(request):
+        if request.url.path.endswith("/robots.txt"):
+            return httpx.Response(200, text="User-agent: *\nAllow: /\n")
+        return inner(request)
+    return handler
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        self.t += s
+
+
+def _discoverer(handler, **kwargs):
+    client = _client(_robots_allow_handler(handler))
+    clock = FakeClock()
+    return WebsiteDiscoverer(
+        client=client,
+        min_interval_s=3.0,
+        jitter_s=0.0,
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=random.Random(0),
+        **kwargs,
+    ), clock
+
+
+# --- pure functions ----------------------------------------------------------
+
+
+def test_tokenize_name_strips_entity_suffixes():
+    assert _tokenize_name("Paniagua Enterprises, Inc.") == {"paniagua", "enterprises"}
+
+
+def test_tokenize_name_drops_stopwords():
+    # The, of, a (via stopwords), b (single-char), & (non-alnum), LLC (stopword),
+    # Company (stopword) → only "ab" would... actually nothing ≥2-char survives.
+    assert _tokenize_name("The Company of A&B LLC") == set()
+    # Realistic case:
+    assert _tokenize_name("The Ruma Company LLC") == {"ruma"}
+
+
+def test_name_overlap_full_match():
+    assert _name_overlap("Paniagua Enterprises Inc", "Paniagua Enterprises Baltimore") == 1.0
+
+
+def test_name_overlap_partial():
+    # "Joe's Pizza and Pasta" → {"joes", "pizza", "pasta"}. Title has 2/3.
+    assert _name_overlap("Joe's Pizza and Pasta", "Joe's Pizza Baltimore") == pytest.approx(2 / 3)
+
+
+def test_host_of_strips_www():
+    assert _host_of("https://www.foo.com/bar") == "foo.com"
+
+
+def test_parse_ddg_results_extracts_two():
+    results = parse_ddg_results(DDG_TWO_HITS_TEMPLATE)
+    assert len(results) == 2
+    assert results[0]["url"] == "https://paniaguaenterprises.com/"
+    assert "yelp.com" in results[1]["url"]
+
+
+# --- discovery end-to-end ---------------------------------------------------
+
+
+def test_discover_happy_path(tmp_path):
+    def handler(request):
+        url = str(request.url)
+        if "duckduckgo.com/html" in url:
+            return httpx.Response(200, text=DDG_TWO_HITS_TEMPLATE)
+        if "paniaguaenterprises.com" in url:
+            return httpx.Response(200, text=HOMEPAGE_HAS_BALTIMORE)
+        return httpx.Response(200, text="")
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    result = discoverer.discover(
+        "Paniagua Enterprises, Inc.",
+        address="123 Main St, Baltimore, MD 21201",
+        phone="410-555-0000",
+    )
+    assert result is not None
+    assert "paniaguaenterprises.com" in result.url
+    assert "city_match" in result.reasons
+
+
+def test_discover_rejects_social_domain(tmp_path):
+    # Only hit is Yelp — must be rejected.
+    ddg_only_yelp = """
+    <html><body>
+      <div class="result">
+        <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//www.yelp.com/biz/x">X</a>
+        <a class="result__snippet">X — Baltimore</a>
+      </div>
+    </body></html>
+    """
+
+    def handler(request):
+        if "duckduckgo.com/html" in str(request.url):
+            return httpx.Response(200, text=ddg_only_yelp)
+        return httpx.Response(200, text=HOMEPAGE_HAS_BALTIMORE)
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    assert discoverer.discover(
+        "X", address="1 Main St, Baltimore, MD 21201"
+    ) is None
+
+
+def test_discover_rejects_namesake_in_wrong_city(tmp_path):
+    # Name matches but homepage doesn't mention Baltimore / zip / phone.
+    def handler(request):
+        if "duckduckgo.com/html" in str(request.url):
+            return httpx.Response(200, text=DDG_NAMESAKE_TEMPLATE)
+        return httpx.Response(200, text=HOMEPAGE_NO_CITY)
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    assert discoverer.discover(
+        "Paniagua Enterprises",
+        address="123 Main St, Baltimore, MD 21201",
+        phone="410-555-0000",
+    ) is None
+
+
+def test_discover_rejects_low_name_overlap(tmp_path):
+    # Title barely mentions the business.
+    weak_html = """
+    <html><body>
+      <div class="result">
+        <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//example.com/">Completely unrelated title</a>
+        <a class="result__snippet">Nothing about the business.</a>
+      </div>
+    </body></html>
+    """
+
+    def handler(request):
+        if "duckduckgo.com/html" in str(request.url):
+            return httpx.Response(200, text=weak_html)
+        return httpx.Response(200, text=HOMEPAGE_HAS_BALTIMORE)
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    assert discoverer.discover(
+        "Paniagua Enterprises Inc",
+        address="1 Main St, Baltimore, MD 21201",
+    ) is None
+
+
+def test_discover_429_trips_breaker(tmp_path):
+    def handler(request):
+        return httpx.Response(429, text="slow down")
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    with pytest.raises(WebsiteDiscoveryCircuitBreakerOpen):
+        discoverer.discover("X", "1 Main St, Baltimore, MD")
+
+
+def test_discover_challenge_page_trips_breaker(tmp_path):
+    def handler(request):
+        return httpx.Response(200, text=CHALLENGE_HTML)
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    with pytest.raises(WebsiteDiscoveryCircuitBreakerOpen):
+        discoverer.discover("X", "1 Main St, Baltimore, MD")
+
+
+def test_discover_rate_limit_sleeps_between_fetches(tmp_path):
+    def handler(request):
+        url = str(request.url)
+        if "duckduckgo.com/html" in url:
+            return httpx.Response(200, text=DDG_TWO_HITS_TEMPLATE)
+        return httpx.Response(200, text=HOMEPAGE_HAS_BALTIMORE)
+
+    discoverer, clock = _discoverer(handler, cache_dir=tmp_path / "c")
+    discoverer.discover(
+        "Paniagua Enterprises, Inc.",
+        address="1 Main St, Baltimore, MD 21201",
+    )
+    # At least one 3.0s sleep between DDG and homepage fetch.
+    assert any(abs(s - 3.0) < 0.01 for s in clock.sleeps), clock.sleeps
+
+
+def test_discover_cache_hits_skip_network(tmp_path):
+    hits = {"n": 0}
+
+    def handler(request):
+        if not request.url.path.endswith("/robots.txt"):
+            hits["n"] += 1
+        url = str(request.url)
+        if "duckduckgo.com/html" in url:
+            return httpx.Response(200, text=DDG_TWO_HITS_TEMPLATE)
+        return httpx.Response(200, text=HOMEPAGE_HAS_BALTIMORE)
+
+    cache = tmp_path / "c"
+    d1, _ = _discoverer(handler, cache_dir=cache)
+    d1.discover(
+        "Paniagua Enterprises, Inc.",
+        address="1 Main St, Baltimore, MD 21201",
+    )
+    first = hits["n"]
+    d2, _ = _discoverer(handler, cache_dir=cache)
+    d2.discover(
+        "Paniagua Enterprises, Inc.",
+        address="1 Main St, Baltimore, MD 21201",
+    )
+    assert hits["n"] == first  # all served from disk
+
+
+def test_robots_disallow_raises_on_init():
+    def handler(request):
+        if request.url.path.endswith("/robots.txt"):
+            return httpx.Response(200, text="User-agent: *\nDisallow: /\n")
+        return httpx.Response(200, text="")
+
+    with pytest.raises(WebsiteDiscoveryCircuitBreakerOpen):
+        WebsiteDiscoverer(client=_client(handler), check_robots=True)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -57,6 +57,23 @@ def test_watermark_scoped_per_source(tmp_path):
     assert r.get_watermark("anne-arundel-license") == 300
 
 
+def test_iter_businesses_missing_website(tmp_path):
+    r = Repository(tmp_path / "t.db")
+    r.upsert_business("k1", RawBusiness(source="a", name="NoSite",
+                                        address="1", phone="410"))
+    r.upsert_business("k2", RawBusiness(source="a", name="HasSite",
+                                        address="2", website="https://x.com"))
+    r.upsert_business("k3", RawBusiness(source="a", name="EmptyStr",
+                                        address="3", website=""))
+    rows = list(r.iter_businesses_missing_website())
+    names = {name for _, name, _, _ in rows}
+    assert names == {"NoSite", "EmptyStr"}
+    # Phone propagates through.
+    for key, _name, _addr, phone in rows:
+        if key == "k1":
+            assert phone == "410"
+
+
 def test_reset_wipes_all_tables(tmp_path):
     r = Repository(tmp_path / "t.db")
     raw = RawBusiness(source="yelp", name="Joe", address="1 Main")


### PR DESCRIPTION
## Summary
- New \`src/shmoney/discover.py\`: \`WebsiteDiscoverer\` + \`WebsiteDiscoveryCircuitBreakerOpen\` + parsers + scorers.
- New CLI verb: \`pipeline discover-websites [--limit N] [--dry-run]\`. Iterates \`businesses WHERE website IS NULL OR website = ''\`.
- Repository: \`iter_businesses_missing_website\`.
- \`beautifulsoup4>=4.12\` added as a dependency.
- README: \`discover-websites\` section documented.

## Strict-match gates (all three required)
1. Candidate domain NOT in social/directory blocklist (facebook, instagram, yelp, bbb, manta, linkedin, yellowpages, crunchbase, etc.).
2. \`name_overlap\` ≥ 0.70 — fraction of normalized business-name tokens appearing in the result title + snippet. Normalization strips entity suffixes (\"LLC\", \"Inc\", \"Corp\", \"Company\"), stopwords (\"the\", \"and\", \"of\"), and single-char tokens (possessive-\`s\` artifacts).
3. Candidate's homepage (single GET, throttled + cached) mentions at least one of: business city, ZIP, or phone digits.

Only candidates that pass all three gates are accepted. Returns the highest-overlap match.

## Ban-avoidance defaults
- 3.0s min interval, ±1.0s jitter.
- Single httpx.Client + cookie jar, realistic browser UA.
- DuckDuckGo \`robots.txt\` consulted at init; disallow → abort.
- 429 → immediate \`WebsiteDiscoveryCircuitBreakerOpen\`.
- Challenge-page substring detection (\"captcha\", \"cloudflare\", \"attention required\", etc.) → abort.
- 5xx tolerated once with 10s backoff; second failure aborts.
- All responses (search + homepage) cached to \`data/discovery_cache/<sha1>.html\`.
- \`--limit\` hard-capped at 500.

## Watermarking
Skipped on purpose. The on-disk cache makes re-runs zero-network, so a killed run resumes at zero cost on the next invocation. No cursor to track.

## Closes
#34

## Human QA steps
- [ ] \`pytest -q\` — 127 passed.
- [ ] \`curl -sS https://html.duckduckgo.com/robots.txt | head -20\` — confirm the \`/html/\` endpoint is not disallowed.
- [ ] \`pipeline discover-websites --dry-run --limit 5\` — prints 5 candidate names, zero network traffic. Verify with \`tcpdump\`.
- [ ] \`pipeline discover-websites --limit 5\` off-hours (20:00–06:00 ET). Observe per-row log lines ≥3s apart. Expect at least one MBE row with \"Inc\" / \"LLC\" to get a URL filled. Check: \`sqlite3 data/pipeline.db \"SELECT name, website FROM businesses WHERE source = 'baltimore-city-license' AND website IS NOT NULL ORDER BY updated_at DESC LIMIT 5\"\`.
- [ ] Re-run the same command — every candidate served from \`data/discovery_cache/\`, zero outbound requests (\`ls data/discovery_cache/\` shows SHA1-named \`.html\` files).
- [ ] \`pipeline sheet-sync\` — Paniagua Enterprises (and peers with newly-discovered sites) fall off row 1 in priority order.
- [ ] Abort drill: \`pipeline discover-websites --limit 200\` with DuckDuckGo temporarily blocked at the firewall. First request fails → circuit breaker raises → CLI exits 2 → no partial state corruption.
- [ ] Edge case: \`--limit 10000\` silently clamped to 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)