### PR TITLE
fix: reduce discover-websites false negatives via domain-match + fallback pages

### DIFF
--- a/src/shmoney/discover.py
+++ b/src/shmoney/discover.py
@@ -93,6 +93,20 @@ def _name_overlap(name: str, candidate_text: str) -> float:
     return hits / len(tokens)
 
 
+def _domain_name_overlap(name: str, host: str) -> float:
+    """How many business-name tokens appear somewhere in the domain label.
+    `synergysystems.com` vs "Synergy Systems Inc" → 1.0 (2/2 tokens)."""
+    tokens = _tokenize_name(name)
+    if not tokens:
+        return 0.0
+    host_core = host.split(".")[0] if host else ""
+    hits = sum(1 for t in tokens if t in host_core)
+    return hits / len(tokens)
+
+
+_FALLBACK_PATHS = ("/contact", "/contact-us", "/about", "/about-us")
+
+
 def _extract_city(address: str) -> Optional[str]:
     # Expect "<street>, <city>, <state> <zip>" — pick the city segment.
     parts = [p.strip() for p in address.split(",")]
@@ -295,41 +309,80 @@ class WebsiteDiscoverer:
                 continue
             if host in _SOCIAL_AND_DIRECTORY_BLOCKLIST:
                 continue
-            overlap = _name_overlap(name, c["title"] + " " + c["snippet"])
-            if overlap < 0.7:
+            title_overlap = _name_overlap(name, c["title"] + " " + c["snippet"])
+            if title_overlap < 0.7:
                 continue
 
-            reasons = [f"name_overlap={overlap:.2f}", f"host={host}"]
+            reasons = [f"title_overlap={title_overlap:.2f}", f"host={host}"]
 
-            # Homepage verification.
-            try:
-                homepage = self._fetch("GET", c["url"])
-            except WebsiteDiscoveryCircuitBreakerOpen:
-                raise
-            except Exception:
+            # Verification signal 1: domain label contains name tokens.
+            # 0.5 is enough when combined with title overlap ≥ 0.7 — the
+            # combination is a very strong signal that this is the business.
+            # Paniagua namesake at 0.0 still fails; Synergy at 2/3 passes.
+            domain_overlap = _domain_name_overlap(name, host)
+            if domain_overlap >= 0.5:
+                reasons.append(f"domain_overlap={domain_overlap:.2f}")
+                candidate = DiscoveryResult(
+                    url=c["url"], confidence=title_overlap, reasons=reasons
+                )
+                if best is None or candidate.confidence > best.confidence:
+                    best = candidate
                 continue
-            homepage_lower = homepage.lower()
-            city_hit = bool(city and city.lower() in homepage_lower)
-            zip_hit = bool(zipc and zipc in homepage_lower)
-            phone_hit = False
-            if phone_digits:
-                homepage_digits = re.sub(r"\D", "", homepage_lower)
-                phone_hit = phone_digits in homepage_digits
-            if not (city_hit or zip_hit or phone_hit):
-                continue
-            if city_hit:
-                reasons.append("city_match")
-            if zip_hit:
-                reasons.append("zip_match")
-            if phone_hit:
-                reasons.append("phone_match")
 
+            # Verification signal 2: root homepage mentions city/zip/phone.
+            # Verification signal 3: fallback to /contact, /about pages when
+            # the root doesn't have the geo signal (common for service
+            # businesses whose landing page is marketing copy).
+            verified, verify_reasons = self._verify_location(
+                c["url"], city, zipc, phone_digits
+            )
+            if not verified:
+                continue
+            reasons.extend(verify_reasons)
             candidate = DiscoveryResult(
-                url=c["url"], confidence=overlap, reasons=reasons
+                url=c["url"], confidence=title_overlap, reasons=reasons
             )
             if best is None or candidate.confidence > best.confidence:
                 best = candidate
         return best
+
+    def _verify_location(
+        self,
+        root_url: str,
+        city: Optional[str],
+        zipc: Optional[str],
+        phone_digits: Optional[str],
+    ) -> tuple[bool, list[str]]:
+        """Fetch root + a few common contact/about paths and look for any
+        city / zip / phone co-mention. Returns (ok, reasons)."""
+        parsed = urllib.parse.urlparse(root_url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        urls_to_try = [root_url] + [base + p for p in _FALLBACK_PATHS]
+        for url in urls_to_try:
+            try:
+                html = self._fetch("GET", url)
+            except WebsiteDiscoveryCircuitBreakerOpen:
+                raise
+            except Exception:
+                continue
+            html_lower = html.lower()
+            city_hit = bool(city and city.lower() in html_lower)
+            zip_hit = bool(zipc and zipc in html_lower)
+            phone_hit = False
+            if phone_digits:
+                html_digits = re.sub(r"\D", "", html_lower)
+                phone_hit = phone_digits in html_digits
+            if city_hit or zip_hit or phone_hit:
+                reasons = []
+                suffix = "" if url == root_url else f" ({parsed.path or '/'})"
+                if city_hit:
+                    reasons.append(f"city_match{suffix}")
+                if zip_hit:
+                    reasons.append(f"zip_match{suffix}")
+                if phone_hit:
+                    reasons.append(f"phone_match{suffix}")
+                return True, reasons
+        return False, []
 
     def close(self) -> None:
         self._client.close()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -149,7 +149,8 @@ def test_discover_happy_path(tmp_path):
     )
     assert result is not None
     assert "paniaguaenterprises.com" in result.url
-    assert "city_match" in result.reasons
+    # Domain match short-circuits the homepage verification.
+    assert any("domain_overlap" in r for r in result.reasons)
 
 
 def test_discover_rejects_social_domain(tmp_path):
@@ -172,6 +173,67 @@ def test_discover_rejects_social_domain(tmp_path):
     assert discoverer.discover(
         "X", address="1 Main St, Baltimore, MD 21201"
     ) is None
+
+
+def test_discover_accepts_when_domain_contains_name_tokens(tmp_path):
+    # Regression for false-negative on Synergy Systems & Services, Inc. —
+    # homepage doesn't mention Baltimore but the domain name does match.
+    ddg_synergy = """
+    <html><body>
+      <div class="result">
+        <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//synergysystems.com/">Synergy Systems &amp; Services Inc — Home</a>
+        <a class="result__snippet">Synergy Systems and Services Inc.</a>
+      </div>
+    </body></html>
+    """
+    bland_homepage = "<html><body><h1>Welcome</h1><p>Enterprise consulting.</p></body></html>"
+
+    def handler(request):
+        if "duckduckgo.com/html" in str(request.url):
+            return httpx.Response(200, text=ddg_synergy)
+        return httpx.Response(200, text=bland_homepage)
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    result = discoverer.discover(
+        "Synergy Systems & Services, Inc.",
+        address="123 Main St, Baltimore, MD 21201",
+    )
+    assert result is not None
+    assert "synergysystems.com" in result.url
+    assert any("domain_overlap" in r for r in result.reasons)
+
+
+def test_discover_falls_back_to_contact_page(tmp_path):
+    # Root homepage has no geo signal; /contact does. Must accept via fallback.
+    # Design: name tokens = {acme, plumbing, baltimore, contractors}.
+    #   title+snippet covers all 4 → title_overlap = 1.0 (passes).
+    #   domain "servicefirm" covers 0/4 → fails domain gate → forces
+    #   location verification path; root fails, /contact hits.
+    ddg = """
+    <html><body>
+      <div class="result">
+        <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//servicefirm.example/">Acme Plumbing Baltimore Contractors</a>
+        <a class="result__snippet">Acme Plumbing Baltimore Contractors service roster.</a>
+      </div>
+    </body></html>
+    """
+
+    def handler(request):
+        url = str(request.url)
+        if "duckduckgo.com/html" in url:
+            return httpx.Response(200, text=ddg)
+        if url.endswith("/contact"):
+            return httpx.Response(200, text="<p>Baltimore, MD office.</p>")
+        # Root homepage + other paths: no geo signal.
+        return httpx.Response(200, text="<html><body>Welcome</body></html>")
+
+    discoverer, _ = _discoverer(handler, cache_dir=tmp_path / "c")
+    result = discoverer.discover(
+        "Acme Plumbing Baltimore Contractors",
+        address="1 Main St, Baltimore, MD 21201",
+    )
+    assert result is not None
+    assert any("city_match" in r for r in result.reasons)
 
 
 def test_discover_rejects_namesake_in_wrong_city(tmp_path):
@@ -231,18 +293,32 @@ def test_discover_challenge_page_trips_breaker(tmp_path):
 
 
 def test_discover_rate_limit_sleeps_between_fetches(tmp_path):
+    # Use a name whose domain doesn't match strongly, so the verification
+    # path forces multiple HTTP calls (DDG + homepage + fallback paths),
+    # exercising the throttle.
+    ddg = """
+    <html><body>
+      <div class="result">
+        <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A//genericsite.example/">Acme Plumbing Baltimore Contractors</a>
+        <a class="result__snippet">Acme Plumbing Baltimore Contractors service.</a>
+      </div>
+    </body></html>
+    """
+
     def handler(request):
         url = str(request.url)
         if "duckduckgo.com/html" in url:
-            return httpx.Response(200, text=DDG_TWO_HITS_TEMPLATE)
-        return httpx.Response(200, text=HOMEPAGE_HAS_BALTIMORE)
+            return httpx.Response(200, text=ddg)
+        if url.endswith("/contact"):
+            return httpx.Response(200, text="<p>Baltimore office.</p>")
+        return httpx.Response(200, text="<html><body>Welcome</body></html>")
 
     discoverer, clock = _discoverer(handler, cache_dir=tmp_path / "c")
     discoverer.discover(
-        "Paniagua Enterprises, Inc.",
+        "Acme Plumbing Baltimore Contractors",
         address="1 Main St, Baltimore, MD 21201",
     )
-    # At least one 3.0s sleep between DDG and homepage fetch.
+    # At least one 3.0s throttle delay between fetches.
     assert any(abs(s - 3.0) < 0.01 for s in clock.sleeps), clock.sleeps
 
 


### PR DESCRIPTION
## Context

Operator reports false-negatives from the current discover-websites gates. Example: \`Synergy Systems & Services, Inc.\` — DDG returns \`synergysystems.com\` on top, but the strict homepage-has-city gate rejects it because the marketing homepage doesn't name Baltimore explicitly.

## Fix

Two layered signals:

1. **Domain-name match short-circuit.** If the candidate domain (first dot-segment) contains ≥50% of the normalized business-name tokens, accept the candidate without fetching the homepage. Real businesses register their name in their domain; paired with the existing ≥0.70 title-overlap requirement, this is high confidence. \`synergysystems.com\` matches \"Synergy Systems & Services\" at 2/3 = 0.67 → accepts.

2. **Fallback verification pages.** When domain overlap is weak, still try root homepage AND \`/contact\`, \`/contact-us\`, \`/about\`, \`/about-us\`. Service businesses typically list city/phone on contact pages rather than the marketing homepage.

Paniagua-in-Texas namesake case still rejects: 0% domain overlap + none of the fallback pages mention Baltimore.

## Closes
— (follow-up fix to #34, no new issue)

## Human QA steps
- [ ] \`pytest -q\` — 129 passed.
- [ ] \`pipeline discover-websites --limit 10 --ignore-robots\` — Synergy-style rows (name-in-domain) now match with reason \`domain_overlap=...\`.
- [ ] Edge: re-run same command — everything served from \`data/discovery_cache/\`, zero net.
- [ ] Precision spot-check: pick 5 newly-matched URLs and open each in a browser — verify they're the right business (not a namesake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)