### PR TITLE
feat: self-enforce Brave Search monthly query budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Defaults:
 - 429 / auth failure / challenge → circuit-breaker abort.
 - All search + homepage responses cached under `data/discovery_cache/`.
 - `--limit` hard-capped at 500.
+- **Monthly budget hard-stop at 900 queries** (buffer under Brave's
+  2000/mo free tier). Persistent per-UTC-month counter in SQLite. Cache
+  hits don't consume budget. Raise with `--monthly-budget N` if you've
+  moved to Brave's paid tier and accept the overage cost.
 
 ```bash
 pipeline discover-websites --dry-run          # prints candidate list, zero network

--- a/src/shmoney/cli.py
+++ b/src/shmoney/cli.py
@@ -186,12 +186,26 @@ def reset(
 
 
 _DISCOVER_HARD_MAX = 500
+_BRAVE_MONTHLY_BUDGET = 900
+
+
+def _brave_month_key(dt=None) -> str:
+    from datetime import datetime as _dt, timezone as _tz
+    dt = dt or _dt.now(_tz.utc)
+    return dt.strftime("%Y-%m")
 
 
 @app.command("discover-websites")
 def discover_websites_cmd(
     limit: int = typer.Option(25, "--limit"),
     dry_run: bool = typer.Option(False, "--dry-run"),
+    monthly_budget: int = typer.Option(
+        _BRAVE_MONTHLY_BUDGET,
+        "--monthly-budget",
+        help="Hard-stop Brave queries at this many in the current UTC month. "
+             "Default is a buffer under Brave's 2000/mo free-tier cap so you "
+             "don't accidentally incur overage charges.",
+    ),
 ) -> None:
     limit = min(max(limit, 0), _DISCOVER_HARD_MAX)
     cfg = load_config()
@@ -222,9 +236,23 @@ def discover_websites_cmd(
                 "https://brave.com/search/api/ (2000 free queries/month) "
                 "and put the key in your .env."
             )
+        month = _brave_month_key()
+        used = repo.get_brave_query_count(month)
+        budget_remaining = max(0, monthly_budget - used)
+        typer.echo(
+            f"[website-discovery] brave_quota month={month} used={used} "
+            f"monthly_budget={monthly_budget} remaining={budget_remaining}"
+        )
+        if budget_remaining == 0:
+            raise typer.BadParameter(
+                f"Monthly Brave budget of {monthly_budget} already used. "
+                f"Raise with --monthly-budget or wait for the next UTC month."
+            )
         discoverer = WebsiteDiscoverer(
             api_key=cfg.brave_api_key,
             cache_dir=cfg.db_path.parent / "discovery_cache",
+            query_budget=budget_remaining,
+            on_query=lambda: repo.bump_brave_query_count(month),
         )
         queried = matched = aborted_on = 0
         aborted: str | None = None

--- a/src/shmoney/discover.py
+++ b/src/shmoney/discover.py
@@ -71,7 +71,7 @@ _FALLBACK_PATHS = ("/contact", "/contact-us", "/about", "/about-us")
 
 
 class WebsiteDiscoveryCircuitBreakerOpen(RuntimeError):
-    """Abort signal — 429 / challenge / repeated 5xx / auth failure."""
+    """Abort signal — 429 / challenge / repeated 5xx / auth failure / budget exhausted."""
 
 
 @dataclass
@@ -178,10 +178,15 @@ class WebsiteDiscoverer:
         sleep: Callable[[float], None] = time.sleep,
         rng: Optional[random.Random] = None,
         cache_dir: Optional[Path] = None,
+        query_budget: Optional[int] = None,
+        on_query: Optional[Callable[[], int]] = None,
     ):
         if not api_key:
             raise ValueError("BRAVE_API_KEY required")
         self.api_key = api_key
+        self._query_budget = query_budget
+        self._on_query = on_query
+        self._queries_this_session = 0
         self.min_interval_s = min_interval_s
         self.jitter_s = jitter_s
         self.user_agent = user_agent
@@ -271,9 +276,25 @@ class WebsiteDiscoverer:
             return text
 
     def _search(self, query: str) -> list[dict]:
+        # Budget check + persistent counter bump BEFORE issuing the request.
+        # Cached lookups don't hit the API, so we only count on cache miss.
+        params = {"q": query, "count": "5"}
+        body = urllib.parse.urlencode(params, doseq=True)
+        key = _cache_key("GET", BRAVE_SEARCH_URL, body)
+        if self._cache_read(key) is None:
+            if (
+                self._query_budget is not None
+                and self._queries_this_session >= self._query_budget
+            ):
+                raise WebsiteDiscoveryCircuitBreakerOpen(
+                    f"Brave query budget exhausted ({self._query_budget})"
+                )
+            self._queries_this_session += 1
+            if self._on_query is not None:
+                self._on_query()
         text = self._fetch(
             BRAVE_SEARCH_URL,
-            params={"q": query, "count": "5"},
+            params=params,
             headers={
                 "Accept": "application/json",
                 "X-Subscription-Token": self.api_key,

--- a/src/shmoney/repo.py
+++ b/src/shmoney/repo.py
@@ -45,6 +45,12 @@ CREATE TABLE IF NOT EXISTS source_watermarks (
     last_run_ts TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS brave_quota (
+    month_key TEXT PRIMARY KEY,
+    count INTEGER NOT NULL DEFAULT 0,
+    last_bumped_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS audits (
     canonical_key TEXT PRIMARY KEY,
     reachable INTEGER NOT NULL,
@@ -254,9 +260,27 @@ class Repository:
         for row in self.conn.execute(sql, params):
             yield (row["canonical_key"], row["name"], row["address"], row["phone"])
 
+    def get_brave_query_count(self, month_key: str) -> int:
+        row = self.conn.execute(
+            "SELECT count FROM brave_quota WHERE month_key = ?", (month_key,)
+        ).fetchone()
+        return int(row["count"]) if row else 0
+
+    def bump_brave_query_count(self, month_key: str) -> int:
+        self.conn.execute(
+            """
+            INSERT INTO brave_quota (month_key, count) VALUES (?, 1)
+            ON CONFLICT(month_key) DO UPDATE SET
+                count = count + 1,
+                last_bumped_at = CURRENT_TIMESTAMP
+            """,
+            (month_key,),
+        )
+        return self.get_brave_query_count(month_key)
+
     def reset(self) -> None:
         for table in ("raw_fetches", "businesses", "sheet_row_map",
-                      "source_watermarks", "audits"):
+                      "source_watermarks", "audits", "brave_quota"):
             self.conn.execute(f"DELETE FROM {table}")
 
     def close(self) -> None:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -277,3 +277,53 @@ def test_discover_cache_hits_skip_network(tmp_path):
 def test_missing_api_key_raises():
     with pytest.raises(ValueError, match="BRAVE_API_KEY"):
         WebsiteDiscoverer(api_key="")
+
+
+def test_query_budget_stops_after_n(tmp_path):
+    bumps = {"n": 0}
+
+    def handler(request):
+        return httpx.Response(200, text=_brave_payload([
+            {"title": "x", "description": "", "url": "https://x.example/"},
+        ]))
+
+    discoverer, _ = _discoverer(
+        handler,
+        cache_dir=tmp_path / "c",
+        query_budget=2,
+        on_query=lambda: bumps.__setitem__("n", bumps["n"] + 1),
+    )
+    discoverer.discover("Biz One", "1 Main St, Baltimore, MD 21201")
+    discoverer.discover("Biz Two", "2 Main St, Baltimore, MD 21201")
+    assert bumps["n"] == 2
+    with pytest.raises(WebsiteDiscoveryCircuitBreakerOpen, match="budget"):
+        discoverer.discover("Biz Three", "3 Main St, Baltimore, MD 21201")
+    assert bumps["n"] == 2  # not bumped for the aborted call
+
+
+def test_cached_searches_dont_consume_budget(tmp_path):
+    bumps = {"n": 0}
+
+    def handler(request):
+        return httpx.Response(200, text=_brave_payload([
+            {"title": "x", "description": "", "url": "https://x.example/"},
+        ]))
+
+    cache = tmp_path / "c"
+    d1, _ = _discoverer(
+        handler,
+        cache_dir=cache,
+        query_budget=10,
+        on_query=lambda: bumps.__setitem__("n", bumps["n"] + 1),
+    )
+    d1.discover("Biz One", "1 Main St, Baltimore, MD 21201")
+    assert bumps["n"] == 1
+
+    d2, _ = _discoverer(
+        handler,
+        cache_dir=cache,
+        query_budget=10,
+        on_query=lambda: bumps.__setitem__("n", bumps["n"] + 1),
+    )
+    d2.discover("Biz One", "1 Main St, Baltimore, MD 21201")
+    assert bumps["n"] == 1  # cache hit, no bump

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -74,6 +74,17 @@ def test_iter_businesses_missing_website(tmp_path):
             assert phone == "410"
 
 
+def test_brave_query_count_roundtrip(tmp_path):
+    r = Repository(tmp_path / "t.db")
+    assert r.get_brave_query_count("2026-04") == 0
+    assert r.bump_brave_query_count("2026-04") == 1
+    assert r.bump_brave_query_count("2026-04") == 2
+    assert r.get_brave_query_count("2026-04") == 2
+    # Different month scopes separately.
+    assert r.bump_brave_query_count("2026-05") == 1
+    assert r.get_brave_query_count("2026-04") == 2
+
+
 def test_reset_wipes_all_tables(tmp_path):
     r = Repository(tmp_path / "t.db")
     raw = RawBusiness(source="yelp", name="Joe", address="1 Main")


### PR DESCRIPTION
## Summary
- New \`brave_quota\` table (\`month_key\`, \`count\`, \`last_bumped_at\`) + \`Repository.get_brave_query_count\` / \`bump_brave_query_count\`.
- \`WebsiteDiscoverer\` accepts \`query_budget\` + \`on_query\` callback. Searches count only on cache miss (cache hits are free). Exceeding the budget raises \`WebsiteDiscoveryCircuitBreakerOpen\` before the HTTP request fires.
- \`pipeline discover-websites\` wires the persistent counter: computes \`budget_remaining = monthly_budget - repo.get_brave_query_count(month)\`, prints a \`brave_quota\` status line at start, fails early with a clear message when budget is exhausted.
- \`--monthly-budget N\` flag. Defaults to **900** — buffer under Brave's 2000/mo free-tier cap so an accidental large run doesn't drop you onto paid tier.
- README updated.
- \`pipeline reset\` now also clears \`brave_quota\`.

## Why
Brave's dashboard doesn't expose a \$0 hard cap — nothing stops a runaway operator script from blowing past 2000 and eating overage charges. This PR self-enforces a cap below the free tier.

## Closes
— (follow-up to #38, no new issue)

## Human QA steps
- [ ] \`pytest -q\` — 134 passed.
- [ ] First run of \`pipeline discover-websites --limit 5\` prints \`[website-discovery] brave_quota month=YYYY-MM used=0 monthly_budget=900 remaining=900\`.
- [ ] After 5 matches, \`sqlite3 data/pipeline.db \"SELECT * FROM brave_quota\"\` shows count ≤ 5 (one per cache-miss search).
- [ ] Re-run same command — cache hits, \`used=5\` unchanged, \`remaining=895\`.
- [ ] Set \`--monthly-budget 3\` on a fresh DB, run \`--limit 10\`: 3 successful matches, then \`ABORT ...: Brave query budget exhausted (3)\`.
- [ ] Edge: \`pipeline reset\` + rerun → counter resets to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)